### PR TITLE
implemented feature to store robohash profile images on our server

### DIFF
--- a/zubhub_backend/zubhub/creators/__init__.py
+++ b/zubhub_backend/zubhub/creators/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'creators.apps.CreatorsConfig'

--- a/zubhub_backend/zubhub/creators/apps.py
+++ b/zubhub_backend/zubhub/creators/apps.py
@@ -3,3 +3,6 @@ from django.apps import AppConfig
 
 class CreatorsConfig(AppConfig):
     name = 'creators'
+
+    def ready(self):
+        import creators.signals

--- a/zubhub_backend/zubhub/creators/serializers.py
+++ b/zubhub_backend/zubhub/creators/serializers.py
@@ -70,6 +70,7 @@ class CreatorSerializer(serializers.ModelSerializer):
         return phone
 
     def update(self, user, validated_data):
+        print("update was called")
         creator = super().update(user, validated_data)
         phone_number = PhoneNumber.objects.filter(user=creator)
         email_address = EmailAddress.objects.filter(user=creator)

--- a/zubhub_backend/zubhub/creators/signals.py
+++ b/zubhub_backend/zubhub/creators/signals.py
@@ -1,6 +1,15 @@
-from django.dispatch import Signal
-
+from django.db.models.signals import pre_delete
+from django.dispatch import Signal, receiver
+from .models import Creator
+# from django.contrib.auth import get_user_model
+from projects.tasks import delete_image_from_DO_space
 # Provides the arguments "request", "phone_number"
 phone_confirmed = Signal()
 # Provides the arguments "request", "confirmation", "signup"
 phone_confirmation_sent = Signal()
+
+
+@receiver(pre_delete, sender=Creator)
+def creator_to_be_deleted(sender, instance, **kwargs):
+    delete_image_from_DO_space.delay(
+        "zubhub", instance.avatar.split(".com/")[1])

--- a/zubhub_backend/zubhub/creators/tasks.py
+++ b/zubhub_backend/zubhub/creators/tasks.py
@@ -1,6 +1,9 @@
 from celery import shared_task
 from random import uniform
-
+import boto3
+import requests
+from django.conf import settings
+# from django.contrib.auth import get_user_model
 try:
     from allauth.account.adapter import get_adapter
 except ImportError:
@@ -11,6 +14,35 @@ except ImportError:
 def send_text(self, phone, template_name, ctx):
     try:
         get_adapter().send_text(template_name, phone, ctx)
+    except Exception as e:
+        raise self.retry(exc=e, countdown=int(
+            uniform(2, 4) ** self.request.retries))
+
+
+@shared_task(name="creators.tasks.upload_image_to_DO_space", bind=True, acks_late=True, max_retries=10)
+def upload_image_to_DO_space(self, bucket, key, user_id):
+    from creators.models import Creator
+
+    creator = Creator.objects.filter(id=user_id)
+
+    session = boto3.session.Session()
+    client = session.client('s3',
+                            region_name=settings.DOSPACE_REGION,
+                            endpoint_url=settings.DOSPACE_ENDPOINT_URL,
+                            aws_access_key_id=settings.DOSPACE_ACCESS_KEY_ID,
+                            aws_secret_access_key=settings.DOSPACE_ACCESS_SECRET_KEY)
+
+    try:
+        res = requests.get(creator[0].avatar)
+        res = client.put_object(Bucket=bucket, Key=key,
+                                Body=res.content, ContentType=res.headers["Content-Type"], ACL="public-read")
+        if res.get("ResponseMetadata") and res["ResponseMetadata"]["HTTPStatusCode"] == 200:
+
+            avatar = 'https://{0}.{1}/{2}'.format(
+                bucket, settings.DOSPACE_ENDPOINT_URL.split("https://")[1], key)
+
+            creator.update(avatar=avatar)
+
     except Exception as e:
         raise self.retry(exc=e, countdown=int(
             uniform(2, 4) ** self.request.retries))

--- a/zubhub_backend/zubhub/creators/views.py
+++ b/zubhub_backend/zubhub/creators/views.py
@@ -16,7 +16,7 @@ from .serializers import CreatorSerializer, LocationSerializer, VerifyPhoneSeria
 from .permissions import IsOwner
 from .models import Location
 from .pagination import CreatorNumberPagination
-from .utils import perform_send_phone_confirmation, perform_send_email_confirmation
+from .utils import perform_send_phone_confirmation, perform_send_email_confirmation, process_avatar
 
 from .models import PhoneConfirmationHMAC
 
@@ -36,14 +36,13 @@ class UserProfileAPIView(RetrieveAPIView):
     lookup_field = "username"
     permission_classes = [AllowAny]
 
-    # perform_send_phone_confirmation
-
 
 class RegisterCreatorAPIView(RegisterView):
     serializer_class = CustomRegisterSerializer
 
     def perform_create(self, serializer):
         creator = super().perform_create(serializer)
+        process_avatar(None, creator)
         perform_send_phone_confirmation(
             self.request._request, creator, signup=True)
         return creator
@@ -87,6 +86,7 @@ class EditCreatorAPIView(UpdateAPIView):
 
             perform_send_email_confirmation(
                 self.request._request, creator[0], signup=True)
+        process_avatar(self.request.user, creator[0])
         return response
 
     def get_object(self):

--- a/zubhub_backend/zubhub/projects/serializers.py
+++ b/zubhub_backend/zubhub/projects/serializers.py
@@ -11,8 +11,7 @@ Creator = get_user_model()
 
 class CommentSerializer(serializers.ModelSerializer):
     id = serializers.UUIDField(read_only=True)
-    creator = serializers.SlugRelatedField(
-        slug_field='username', read_only=True)
+    creator = CreatorSerializer(read_only=True)
     created_on = serializers.DateTimeField(read_only=True)
 
     class Meta:

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/error/errorPageStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/error/errorPageStyles.js
@@ -33,7 +33,7 @@ const styles = theme => ({
     },
   },
   disconnectedStyle: {
-    height:'20em',
+    height: '20em',
     [theme.breakpoints.down('500')]: {
       height: '10em',
     },

--- a/zubhub_frontend/zubhub/src/store/actions/authActions.js
+++ b/zubhub_frontend/zubhub/src/store/actions/authActions.js
@@ -34,7 +34,7 @@ export const logout = args => {
       .then(res => {
         dispatch({
           type: 'SET_AUTH_USER',
-          payload: { token: null, username: null, id: null },
+          payload: { token: null, username: null, id: null, avatar: null },
         });
       })
       .then(res => {
@@ -56,7 +56,12 @@ export const get_auth_user = props => {
 
         dispatch({
           type: 'SET_AUTH_USER',
-          payload: { ...props.auth, username: res.username, id: res.id },
+          payload: {
+            ...props.auth,
+            username: res.username,
+            id: res.id,
+            avatar: res.avatar,
+          },
         });
 
         return res;

--- a/zubhub_frontend/zubhub/src/store/actions/userActions.js
+++ b/zubhub_frontend/zubhub/src/store/actions/userActions.js
@@ -42,6 +42,7 @@ export const edit_user_profile = args => {
       if (res.id) {
         dispatch(
           AuthActions.setAuthUser({
+            avatar: res.avatar,
             username: res.username,
           }),
         );

--- a/zubhub_frontend/zubhub/src/store/reducers/authReducer.js
+++ b/zubhub_frontend/zubhub/src/store/reducers/authReducer.js
@@ -1,4 +1,4 @@
-const defaultState = { token: null, username: null, id: null };
+const defaultState = { token: null, username: null, id: null, avatar: null };
 
 const auth = (state = defaultState, action) => {
   switch (action.type) {

--- a/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
+++ b/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
@@ -153,7 +153,7 @@ function PageWrapper(props) {
                     aria-controls="profile_menu"
                     aria-haspopup="true"
                     onClick={e => handleSetState(handleProfileMenuOpen(e))}
-                    src={`https://robohash.org/${props.auth.username}`}
+                    src={props.auth.avatar}
                     alt={props.auth.username}
                   />
                   <Menu

--- a/zubhub_frontend/zubhub/src/views/email_confirm/EmailConfirm.jsx
+++ b/zubhub_frontend/zubhub/src/views/email_confirm/EmailConfirm.jsx
@@ -39,11 +39,9 @@ const confirmEmail = (e, props, state) => {
     })
     .catch(error => {
       if (error.message.startsWith('Unexpected')) {
-        props.setStatus({
-          non_field_errors: props.t('emailConfirm.errors.unexpected'),
-        });
+        return { errors: props.t('emailConfirm.errors.unexpected') };
       } else {
-        props.setStatus({ non_field_errors: error.message });
+        return { errors: error.message };
       }
     });
 };
@@ -53,10 +51,19 @@ function EmailConfirm(props) {
 
   let { username, key } = getUsernameAndKey(props.location.search);
 
-  const [state] = React.useState({
+  const [state, setState] = React.useState({
     username: username ?? null,
     key: key ?? null,
+    errors: null,
   });
+
+  const handleSetState = obj => {
+    if (obj) {
+      Promise.resolve(obj).then(obj => {
+        setState({ ...state, ...obj });
+      });
+    }
+  };
 
   username = state.username;
   const { t } = props;
@@ -71,7 +78,7 @@ function EmailConfirm(props) {
                 className="auth-form"
                 name="email_confirm"
                 noValidate="noValidate"
-                onSubmit={e => confirmEmail(e, props, state)}
+                onSubmit={e => handleSetState(confirmEmail(e, props, state))}
               >
                 <Typography
                   gutterBottom

--- a/zubhub_frontend/zubhub/src/views/phone_confirm/PhoneConfirm.jsx
+++ b/zubhub_frontend/zubhub/src/views/phone_confirm/PhoneConfirm.jsx
@@ -39,11 +39,11 @@ const confirmPhone = (e, props, state) => {
     })
     .catch(error => {
       if (error.message.startsWith('Unexpected')) {
-        props.setStatus({
-          non_field_errors: props.t('phoneConfirm.errors.unexpected'),
-        });
+        return {
+          errors: props.t('phoneConfirm.errors.unexpected'),
+        };
       } else {
-        props.setStatus({ non_field_errors: error.message });
+        return { errors: error.message };
       }
     });
 };
@@ -53,12 +53,22 @@ function PhoneConfirm(props) {
 
   let { username, key } = getUsernameAndKey(props.location.search);
 
-  const [state] = React.useState({
+  const [state, setState] = React.useState({
     username: username ?? null,
     key: key ?? null,
+    errors: null,
   });
 
+  const handleSetState = obj => {
+    if (obj) {
+      Promise.resolve(obj).then(obj => {
+        setState({ ...state, ...obj });
+      });
+    }
+  };
+
   username = state.username;
+  let errors = state.errors;
   const { t } = props;
 
   return (
@@ -71,7 +81,7 @@ function PhoneConfirm(props) {
                 className="auth-form"
                 name="phone_confirm"
                 noValidate="noValidate"
-                onSubmit={e => confirmPhone(e, props, state)}
+                onSubmit={e => handleSetState(confirmPhone(e, props, state))}
               >
                 <Typography
                   gutterBottom
@@ -91,17 +101,10 @@ function PhoneConfirm(props) {
 
                 <Grid container spacing={3}>
                   <Grid item xs={12}>
-                    <Box
-                      component="p"
-                      className={
-                        props.status &&
-                        props.status['non_field_errors'] &&
-                        classes.errorBox
-                      }
-                    >
-                      {props.status && props.status['non_field_errors'] && (
+                    <Box component="p" className={errors && classes.errorBox}>
+                      {errors && (
                         <Box component="span" className={classes.error}>
-                          {props.status['non_field_errors']}
+                          {errors}
                         </Box>
                       )}
                     </Box>

--- a/zubhub_frontend/zubhub/src/views/project_details/ProjectDetails.jsx
+++ b/zubhub_frontend/zubhub/src/views/project_details/ProjectDetails.jsx
@@ -484,7 +484,7 @@ function ProjectDetails(props) {
                     {props.auth.token ? (
                       <Avatar
                         className={classes.commentAvatarStyle}
-                        src={`https://robohash.org/${props.auth.username}`}
+                        src={props.auth.avatar}
                         alt={props.auth.username}
                       />
                     ) : null}
@@ -536,12 +536,12 @@ function ProjectDetails(props) {
                     >
                       <Avatar
                         className={classes.commentAvatarStyle}
-                        src={`https://robohash.org/${comment.creator}`}
-                        alt={comment.creator}
+                        src={comment.creator.avatar}
+                        alt={comment.creator.username}
                       />
                       <Box>
                         <Typography color="textPrimary">
-                          {comment.creator}
+                          {comment.creator.username}
                         </Typography>
                         <Typography variant="body2" color="textSecondary">
                           {`${dFormatter(comment.created_on).value} ${t(


### PR DESCRIPTION
Before this PR, every request for a creator's profile image fetches the corresponding robohash image from robohash.org server. As we grow, this is going to cause rate-limit issues since we will be hitting robohash server alot. This PR fixes that by only storing the url pointing to the robohash server temporarily while running a background task that fetches the robohash image from robohash server and uploading it to our digitalocean space. Once this background task is completed, the task changes the avatar url to point to our digitialocean space instead