### PR TITLE
fixed issue #180: Added a link to view gdrive videos for when mobile safari and firefox fails to play video

### DIFF
--- a/zubhub_frontend/zubhub/src/views/project_details/ProjectDetails.jsx
+++ b/zubhub_frontend/zubhub/src/views/project_details/ProjectDetails.jsx
@@ -53,6 +53,9 @@ const handleToggleDeleteProjectModal = state => {
   return { openDeleteProjectModal };
 };
 
+const isVideoFromGdrive = link =>
+  link.search('https://drive.google.com') !== -1 ? true : false;
+
 const deleteProject = (props, state) => {
   if (props.auth.token && props.auth.id === state.project.creator.id) {
     return props
@@ -287,6 +290,18 @@ function ProjectDetails(props) {
                         src={project.images[0].image_url}
                         alt={project.title}
                       />
+                    ) : null}
+                  </Grid>
+                  <Grid item xs={12} sm={12} md={12}>
+                    {project.video && isVideoFromGdrive(project.video) ? (
+                      <a
+                        className={commonClasses.floatRight}
+                        href={project.video}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        Can't play video? click here
+                      </a>
                     ) : null}
                   </Grid>
                   <Box className={classes.actionBoxStyle}>


### PR DESCRIPTION
### Issue fixed: #180 

### What was done:
* This issue was an Issue that originates from google servers (when embedding video from gdrive). Because of this, a direct fix is not possible. What I did was add a link below the video Iframe directing users to open the video on a new window if it was detected that the video comes gdrive.

### Possible Improvements
This fix can be improved further by targeting and only showing the link to mobile safari and firefox users. Because of the issues and inconsistencies that affect user-agent detection, I chose to make it more broad and show the link to all users who view the project with a gdrive video link. It is better that a user who doesn't need the link see it, than for a user who needs the link not to see it.