### PR TITLE
fixed issue #179 and #165: Fixed bug in the staff picks feature and related console errors

### DIFF
--- a/zubhub_backend/zubhub/projects/views.py
+++ b/zubhub_backend/zubhub/projects/views.py
@@ -6,7 +6,6 @@ from django.contrib.auth.models import AnonymousUser
 from django.contrib.postgres.search import SearchQuery, SearchRank
 from django.db.models import F
 from rest_framework import status
-from rest_framework.exceptions import NotFound
 from rest_framework.generics import (UpdateAPIView, CreateAPIView,
                                      ListAPIView, RetrieveAPIView, DestroyAPIView)
 from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly, AllowAny
@@ -234,10 +233,7 @@ class StaffPickListAPIView(ListAPIView):
     throttle_classes = [GetUserRateThrottle,  SustainedRateThrottle]
 
     def get_queryset(self):
-        result = StaffPick.objects.filter(is_active=True)
-        if result:
-            return result
-        raise NotFound(detail=_('page not found'), code=404)
+        return StaffPick.objects.filter(is_active=True)
 
 
 class StaffPickDetailsAPIView(RetrieveAPIView):

--- a/zubhub_frontend/zubhub/src/api/api.js
+++ b/zubhub_frontend/zubhub/src/api/api.js
@@ -458,9 +458,7 @@ class API {
   /************************** get staff picks **************************/
   get_staff_picks = () => {
     const url = 'projects/staff_picks/';
-    return this.request({ url}).then(res =>
-      Promise.resolve(res.status === 200 ? { detail: 'ok' } :(res.status === 404 ? {detail: "not found"} : res.json())),
-    );
+    return this.request({ url}).then(res => res.json());
   };
   /******************************************************************/
 

--- a/zubhub_frontend/zubhub/src/store/actions/projectActions.js
+++ b/zubhub_frontend/zubhub/src/store/actions/projectActions.js
@@ -360,6 +360,7 @@ export const get_staff_picks = args => {
           dispatch(set_staff_picks(res));
           return { loading: false };
         }else if (res.detail === "not found"){
+          console.log("res.detail === not found");
           dispatch(set_staff_picks([]));
         } else {
           dispatch(set_staff_picks([]));


### PR DESCRIPTION
### Issues fixed: #179 and #165

### What was done:
* Fixed bug that caused staff picks not to be displayed
* Changed response and status code of staff pick responses so that 404 errors doesn't get displayed when no staff pick is added