### PR TITLE
Add notification button components

### DIFF
--- a/zubhub_frontend/zubhub/src/assets/js/styles/components/notification_button/notificationButtonStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/components/notification_button/notificationButtonStyles.js
@@ -1,0 +1,7 @@
+const styles = theme => ({
+  notificationButtonStyle: {
+    minWidth: '0px !important',
+  },
+});
+
+export default styles;

--- a/zubhub_frontend/zubhub/src/assets/js/styles/components/notification_panel/notificationPanelButtonStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/components/notification_panel/notificationPanelButtonStyles.js
@@ -1,0 +1,17 @@
+const styles = theme => ({
+  buttonStyle: {
+    borderRadius: '30px',
+    padding: '5px 15px',
+    color: '#757575',
+    backgroundColor: '#E4E4E4',
+    outline: 'none',
+    border: 'none',
+    cursor: 'pointer',
+  },
+  selectedButtonStyle: {
+    backgroundColor: '#00B8C4',
+    color: 'white',
+  },
+});
+
+export default styles;

--- a/zubhub_frontend/zubhub/src/assets/js/styles/components/notification_panel/notificationPanelButtonStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/components/notification_panel/notificationPanelButtonStyles.js
@@ -7,6 +7,7 @@ const styles = theme => ({
     outline: 'none',
     border: 'none',
     cursor: 'pointer',
+    fontSize: '15px',
   },
   selectedButtonStyle: {
     backgroundColor: '#00B8C4',

--- a/zubhub_frontend/zubhub/src/assets/js/styles/components/notification_panel/notificationPanelPopperStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/components/notification_panel/notificationPanelPopperStyles.js
@@ -1,0 +1,18 @@
+const styles = theme => ({
+  popperContainerStyle: {
+    top: '56px !important',
+  },
+  popperArrowStyle: {
+    width: '50px',
+    height: '50px',
+    top: '-20px',
+    background: 'white',
+    position: 'absolute',
+    transform: 'scaleX(0.7) rotate(45deg)',
+    transformOrigin: 'center',
+    borderRadius: '10px',
+    zIndex: '-1',
+  },
+});
+
+export default styles;

--- a/zubhub_frontend/zubhub/src/assets/js/styles/components/notification_panel/notificationPanelPopperStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/components/notification_panel/notificationPanelPopperStyles.js
@@ -5,13 +5,13 @@ const styles = theme => ({
   popperArrowStyle: {
     width: '50px',
     height: '50px',
-    top: '-20px',
+    top: '-19px',
     background: 'white',
     position: 'absolute',
     transform: 'scaleX(0.7) rotate(45deg)',
     transformOrigin: 'center',
-    borderRadius: '10px',
-    zIndex: '-1',
+    borderRadius: '200px 0px 1000px 0px',
+    zIndex: '2000',
   },
 });
 

--- a/zubhub_frontend/zubhub/src/assets/js/styles/components/notification_panel/notificationPanelStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/components/notification_panel/notificationPanelStyles.js
@@ -4,6 +4,7 @@ const styles = theme => ({
     zIndex: 20,
     padding: '20px',
     borderRadius: '20px',
+    boxShadow: '0px 4px 4px 0px rgb(0 0 0 / 25%)',
   },
   popperArrowStyle: {
     width: '50px',

--- a/zubhub_frontend/zubhub/src/assets/js/styles/components/notification_panel/notificationPanelStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/components/notification_panel/notificationPanelStyles.js
@@ -1,4 +1,7 @@
 const styles = theme => ({
+  popperContainerStyle: {
+    top: '48px !important',
+  },
   popperStyle: {
     backgroundColor: 'white',
     zIndex: 20,
@@ -6,16 +9,10 @@ const styles = theme => ({
     borderRadius: '20px',
     boxShadow: '0px 4px 4px 0px rgb(0 0 0 / 25%)',
   },
-  popperArrowStyle: {
-    width: '50px',
-    height: '50px',
-    top: '-20px',
-    background: 'white',
-    position: 'absolute',
-    transform: 'scaleX(0.7) rotate(45deg)',
-    transformOrigin: 'center',
-    borderRadius: '10px',
-    zIndex: '-1',
+  fullscreenPopperStyle: {
+    width: '100vw',
+    height: '100vh',
+    borderRadius: '0px',
   },
   panelHeaderStyle: {
     display: 'flex',

--- a/zubhub_frontend/zubhub/src/assets/js/styles/components/notification_panel/notificationPanelStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/components/notification_panel/notificationPanelStyles.js
@@ -1,0 +1,41 @@
+const styles = theme => ({
+  popperStyle: {
+    backgroundColor: 'white',
+    zIndex: 20,
+    padding: '20px',
+    borderRadius: '20px',
+  },
+  popperArrowStyle: {
+    width: '50px',
+    height: '50px',
+    top: '-20px',
+    background: 'white',
+    position: 'absolute',
+    transform: 'scaleX(0.7) rotate(45deg)',
+    transformOrigin: 'center',
+    borderRadius: '10px',
+    zIndex: '-1',
+  },
+  panelHeaderStyle: {
+    display: 'flex',
+    flexFlow: 'row nowrap',
+    alignItems: 'center',
+    gap: '10px',
+    color: '#00B8C4',
+  },
+  panelHeaderTextStyle: {
+    margin: '0px',
+    marginRight: '30px',
+    fontWeight: '600',
+  },
+  panelSubheadingTextStyle: {
+    margin: '5px 0px',
+    fontWeight: '600',
+    color: '#00B8C4',
+  },
+  fullWidth: {
+    width: '100%',
+  },
+});
+
+export default styles;

--- a/zubhub_frontend/zubhub/src/components/notification_button/NotificationButton.jsx
+++ b/zubhub_frontend/zubhub/src/components/notification_button/NotificationButton.jsx
@@ -1,0 +1,32 @@
+import React, { useRef, useState } from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import NotificationPanel from '../notification_panel/NotificationPanel';
+import NotificationsIcon from '@material-ui/icons/Notifications';
+import CustomButton from '../button/Button';
+
+const useStyles = makeStyles(theme => ({
+  paper: {
+    border: '1px solid',
+    padding: theme.spacing(1),
+    backgroundColor: theme.palette.background.paper,
+  },
+}));
+
+const NotificationButton = () => {
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const buttonRef = useRef();
+
+  return (
+    <>
+      <CustomButton
+        onClick={() => setDropdownOpen(!dropdownOpen)}
+        ref={buttonRef}
+      >
+        <NotificationsIcon />
+      </CustomButton>
+      <NotificationPanel open={dropdownOpen} anchorEl={buttonRef} />
+    </>
+  );
+};
+
+export default NotificationButton;

--- a/zubhub_frontend/zubhub/src/components/notification_button/NotificationButton.jsx
+++ b/zubhub_frontend/zubhub/src/components/notification_button/NotificationButton.jsx
@@ -1,19 +1,16 @@
 import React, { useRef, useState } from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import NotificationPanel from '../notification_panel/NotificationPanel';
 import NotificationsIcon from '@material-ui/icons/Notifications';
 import CustomButton from '../button/Button';
 import ClickAwayListener from '@material-ui/core/ClickAwayListener';
+import cn from 'classnames';
+import styles from '../../assets/js/styles/components/notification_button/notificationButtonStyles';
+import { makeStyles } from '@material-ui/core/styles';
 
-const useStyles = makeStyles(theme => ({
-  paper: {
-    border: '1px solid',
-    padding: theme.spacing(1),
-    backgroundColor: theme.palette.background.paper,
-  },
-}));
+const useStyles = makeStyles(styles);
 
 const NotificationButton = ({ className }) => {
+  const classes = useStyles();
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const buttonRef = useRef();
 
@@ -21,7 +18,7 @@ const NotificationButton = ({ className }) => {
     <ClickAwayListener onClickAway={() => setDropdownOpen(false)}>
       <div>
         <CustomButton
-          className={className}
+          className={cn(className, classes.notificationButtonStyle)}
           variant="contained"
           primaryButtonStyle
           customButtonStyle

--- a/zubhub_frontend/zubhub/src/components/notification_button/NotificationButton.jsx
+++ b/zubhub_frontend/zubhub/src/components/notification_button/NotificationButton.jsx
@@ -3,6 +3,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import NotificationPanel from '../notification_panel/NotificationPanel';
 import NotificationsIcon from '@material-ui/icons/Notifications';
 import CustomButton from '../button/Button';
+import ClickAwayListener from '@material-ui/core/ClickAwayListener';
 
 const useStyles = makeStyles(theme => ({
   paper: {
@@ -12,20 +13,27 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const NotificationButton = () => {
+const NotificationButton = ({ className }) => {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const buttonRef = useRef();
 
   return (
-    <>
-      <CustomButton
-        onClick={() => setDropdownOpen(!dropdownOpen)}
-        ref={buttonRef}
-      >
-        <NotificationsIcon />
-      </CustomButton>
-      <NotificationPanel open={dropdownOpen} anchorEl={buttonRef} />
-    </>
+    <ClickAwayListener onClickAway={() => setDropdownOpen(false)}>
+      <div>
+        <CustomButton
+          className={className}
+          variant="contained"
+          primaryButtonStyle
+          customButtonStyle
+          size="small"
+          onClick={() => setDropdownOpen(!dropdownOpen)}
+          ref={buttonRef}
+        >
+          <NotificationsIcon />
+        </CustomButton>
+        <NotificationPanel open={dropdownOpen} anchorEl={buttonRef} />
+      </div>
+    </ClickAwayListener>
   );
 };
 

--- a/zubhub_frontend/zubhub/src/components/notification_panel/NotificationPanel.jsx
+++ b/zubhub_frontend/zubhub/src/components/notification_panel/NotificationPanel.jsx
@@ -37,7 +37,7 @@ const NotificationPanel = ({ open, anchorEl }) => {
   };
 
   const getUnreadNotificationView = () => (
-    <div>Unread notifications here...</div>
+    <div style={{ color: 'black' }}>Unread notifications here...</div>
   );
 
   return (

--- a/zubhub_frontend/zubhub/src/components/notification_panel/NotificationPanel.jsx
+++ b/zubhub_frontend/zubhub/src/components/notification_panel/NotificationPanel.jsx
@@ -1,15 +1,84 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Popper from '@material-ui/core/Popper';
-import { useEffect } from 'react';
+import styles from '../../assets/js/styles/components/notification_panel/notificationPanelStyles';
+import { makeStyles } from '@material-ui/core/styles';
+import NotificationPanelButton from './NotificationPanelButton';
+
+const useStyles = makeStyles(styles);
+
+const NOTIFICATION_VIEW_TYPE = {
+  ALL: 'ALL',
+  UNREAD: 'UNREAD',
+};
+
+const modifiers = {
+  offset: {
+    enabled: true,
+    offset: '20px, 30px',
+  },
+  arrow: {
+    enabled: true,
+  },
+};
 
 const NotificationPanel = ({ open, anchorEl }) => {
-  console.log(open);
-  useEffect(() => {
-    console.log(anchorEl);
-  }, [anchorEl]);
+  const classes = useStyles();
+  const [notificationViewType, setNotificationViewType] = useState(
+    NOTIFICATION_VIEW_TYPE.ALL,
+  );
+
+  const getAllNotificationView = () => {
+    const newNotificationsLength = 1;
+    const earlierNotificationsLength = 1;
+
+    return (
+      <div>
+        {newNotificationsLength > 0 && (
+          <h2 className={classes.panelSubheadingTextStyle}>New</h2>
+        )}
+        {earlierNotificationsLength > 0 && (
+          <h2 className={classes.panelSubheadingTextStyle}>Earlier</h2>
+        )}
+      </div>
+    );
+  };
+
+  const getUnreadNotificationView = () => (
+    <div>Unread notifications here...</div>
+  );
+
   return (
-    <Popper id={'yo'} open={open} anchorEl={anchorEl.current} disablePortal>
-      <div>The content of the Popper.</div>
+    <Popper
+      open={open}
+      anchorEl={anchorEl.current}
+      disablePortal
+      modifiers={modifiers}
+      placement="bottom-end"
+    >
+      <div x-arrow="true" className={classes.popperArrowStyle}></div>
+
+      <div className={classes.popperStyle}>
+        <div className={classes.panelHeaderStyle}>
+          <h1 className={classes.panelHeaderTextStyle}>Notifications</h1>
+          <NotificationPanelButton
+            selected={notificationViewType === NOTIFICATION_VIEW_TYPE.ALL}
+            onClick={() => setNotificationViewType(NOTIFICATION_VIEW_TYPE.ALL)}
+          >
+            All
+          </NotificationPanelButton>
+          <NotificationPanelButton
+            selected={notificationViewType === NOTIFICATION_VIEW_TYPE.UNREAD}
+            onClick={() =>
+              setNotificationViewType(NOTIFICATION_VIEW_TYPE.UNREAD)
+            }
+          >
+            Unread
+          </NotificationPanelButton>
+        </div>
+        {notificationViewType === NOTIFICATION_VIEW_TYPE.ALL
+          ? getAllNotificationView()
+          : getUnreadNotificationView()}
+      </div>
     </Popper>
   );
 };

--- a/zubhub_frontend/zubhub/src/components/notification_panel/NotificationPanel.jsx
+++ b/zubhub_frontend/zubhub/src/components/notification_panel/NotificationPanel.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import Popper from '@material-ui/core/Popper';
+
+const NotificationPanel = ({ open, anchorEl }) => {
+  return (
+    <Popper id={'yo'} open={open} anchorEl={anchorEl}>
+      <div>The content of the Popper.</div>
+    </Popper>
+  );
+};
+
+export default NotificationPanel;

--- a/zubhub_frontend/zubhub/src/components/notification_panel/NotificationPanel.jsx
+++ b/zubhub_frontend/zubhub/src/components/notification_panel/NotificationPanel.jsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
-import Popper from '@material-ui/core/Popper';
 import styles from '../../assets/js/styles/components/notification_panel/notificationPanelStyles';
 import { makeStyles } from '@material-ui/core/styles';
 import NotificationPanelButton from './NotificationPanelButton';
+import cn from 'classnames';
+import NotificationPanelPopper from './NotificationPanelPopper';
+import { useMediaQuery } from '@material-ui/core';
 
 const useStyles = makeStyles(styles);
 
@@ -11,18 +13,9 @@ const NOTIFICATION_VIEW_TYPE = {
   UNREAD: 'UNREAD',
 };
 
-const modifiers = {
-  offset: {
-    enabled: true,
-    offset: '20px, 30px',
-  },
-  arrow: {
-    enabled: true,
-  },
-};
-
 const NotificationPanel = ({ open, anchorEl }) => {
   const classes = useStyles();
+  const mediaQuery = useMediaQuery('(max-width: 600px)');
   const [notificationViewType, setNotificationViewType] = useState(
     NOTIFICATION_VIEW_TYPE.ALL,
   );
@@ -48,16 +41,13 @@ const NotificationPanel = ({ open, anchorEl }) => {
   );
 
   return (
-    <Popper
-      open={open}
-      anchorEl={anchorEl.current}
-      disablePortal
-      modifiers={modifiers}
-      placement="bottom-end"
-    >
-      <div x-arrow="true" className={classes.popperArrowStyle}></div>
-
-      <div className={classes.popperStyle}>
+    <NotificationPanelPopper open={open} anchorEl={anchorEl}>
+      <div
+        className={cn(
+          classes.popperStyle,
+          mediaQuery ? classes.fullscreenPopperStyle : '',
+        )}
+      >
         <div className={classes.panelHeaderStyle}>
           <h1 className={classes.panelHeaderTextStyle}>Notifications</h1>
           <NotificationPanelButton
@@ -79,7 +69,7 @@ const NotificationPanel = ({ open, anchorEl }) => {
           ? getAllNotificationView()
           : getUnreadNotificationView()}
       </div>
-    </Popper>
+    </NotificationPanelPopper>
   );
 };
 

--- a/zubhub_frontend/zubhub/src/components/notification_panel/NotificationPanel.jsx
+++ b/zubhub_frontend/zubhub/src/components/notification_panel/NotificationPanel.jsx
@@ -1,9 +1,14 @@
 import React from 'react';
 import Popper from '@material-ui/core/Popper';
+import { useEffect } from 'react';
 
 const NotificationPanel = ({ open, anchorEl }) => {
+  console.log(open);
+  useEffect(() => {
+    console.log(anchorEl);
+  }, [anchorEl]);
   return (
-    <Popper id={'yo'} open={open} anchorEl={anchorEl}>
+    <Popper id={'yo'} open={open} anchorEl={anchorEl.current} disablePortal>
       <div>The content of the Popper.</div>
     </Popper>
   );

--- a/zubhub_frontend/zubhub/src/components/notification_panel/NotificationPanelButton.jsx
+++ b/zubhub_frontend/zubhub/src/components/notification_panel/NotificationPanelButton.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import styles from '../../assets/js/styles/components/notification_panel/notificationPanelButtonStyles';
+import { makeStyles } from '@material-ui/core/styles';
+import cn from 'classnames';
+
+const useStyles = makeStyles(styles);
+
+const NotificationPanelButton = ({ selected, children, ...rest }) => {
+  const classNames = useStyles();
+
+  const selectedButtonClassName = selected
+    ? classNames.selectedButtonStyle
+    : '';
+
+  return (
+    <button
+      className={cn(classNames.buttonStyle, selectedButtonClassName)}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default NotificationPanelButton;

--- a/zubhub_frontend/zubhub/src/components/notification_panel/NotificationPanelPopper.jsx
+++ b/zubhub_frontend/zubhub/src/components/notification_panel/NotificationPanelPopper.jsx
@@ -1,0 +1,43 @@
+import { useMediaQuery } from '@material-ui/core';
+import React from 'react';
+import Popper from '@material-ui/core/Popper';
+import { makeStyles } from '@material-ui/core/styles';
+
+import styles from '../../assets/js/styles/components/notification_panel/notificationPanelPopperStyles';
+
+const useStyles = makeStyles(styles);
+
+const modifiers = {
+  offset: {
+    enabled: true,
+    offset: '20px, 30px',
+  },
+  arrow: {
+    enabled: true,
+  },
+};
+
+const fullscreenModifiers = {};
+
+const NotificationPanelPopper = ({ open, anchorEl, children }) => {
+  const classes = useStyles();
+  const mediaQuery = useMediaQuery('(max-width: 600px)');
+
+  return (
+    <Popper
+      open={open}
+      anchorEl={mediaQuery ? undefined : anchorEl.current}
+      disablePortal={!mediaQuery}
+      modifiers={mediaQuery ? fullscreenModifiers : modifiers}
+      placement="bottom-end"
+      className={mediaQuery ? classes.popperContainerStyle : ''}
+    >
+      {!mediaQuery && (
+        <div x-arrow="true" className={classes.popperArrowStyle}></div>
+      )}
+      {children}
+    </Popper>
+  );
+};
+
+export default NotificationPanelPopper;

--- a/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
+++ b/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
@@ -326,7 +326,9 @@ function PageWrapper(props) {
                   >
                     <SearchIcon />
                   </IconButton>
-                  <NotificationButton />
+                  <NotificationButton
+                    className={clsx(common_classes.marginRight1em)}
+                  />
                   <Avatar
                     className={classes.avatarStyle}
                     aria-label={`${props.auth.username}' Avatar`}

--- a/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
+++ b/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
@@ -56,16 +56,17 @@ import styles from '../assets/js/styles/views/page_wrapper/pageWrapperStyles';
 import commonStyles from '../assets/js/styles';
 
 import languageMap from '../assets/js/languageMap.json';
+import NotificationButton from '../components/notification_button/NotificationButton';
 
 const useStyles = makeStyles(styles);
 const useCommonStyles = makeStyles(commonStyles);
 
 /**
-* @function PageWrapper View
-* @author Raymond Ndibe <ndiberaymond1@gmail.com>
-* 
-* @todo - describe function's signature
-*/
+ * @function PageWrapper View
+ * @author Raymond Ndibe <ndiberaymond1@gmail.com>
+ *
+ * @todo - describe function's signature
+ */
 function PageWrapper(props) {
   const backToTopEl = React.useRef(null);
   const classes = useStyles();
@@ -325,6 +326,7 @@ function PageWrapper(props) {
                   >
                     <SearchIcon />
                   </IconButton>
+                  <NotificationButton />
                   <Avatar
                     className={classes.avatarStyle}
                     aria-label={`${props.auth.username}' Avatar`}


### PR DESCRIPTION
## Summary

Closes #298 

This won't be merged into master without the content being done, perhaps that will be merged in here.

## Changes

- Adds the notification dropdown panel

## Screenshots

In navbar:
<img width="283" alt="image" src="https://user-images.githubusercontent.com/23221268/155453575-c3e5f35f-7886-47c2-8dfb-780716536969.png">

Opened:
<img width="434" alt="image" src="https://user-images.githubusercontent.com/23221268/155454617-fdd5b170-6f29-4ddd-bc5e-8bf681b6212f.png">


<img width="422" alt="image" src="https://user-images.githubusercontent.com/23221268/155454604-11c61767-1f08-4b12-9da8-062b37ef8a94.png">

<img width="507" alt="image" src="https://user-images.githubusercontent.com/23221268/155458831-47a2233c-869e-4ae0-a982-cb1d79d40b9d.png">
