### PR TITLE
use minimal creator serializer if user is not the authenticated user

### DIFF
--- a/zubhub_backend/zubhub/creators/serializers.py
+++ b/zubhub_backend/zubhub/creators/serializers.py
@@ -14,29 +14,30 @@ from projects.utils import parse_comment_trees
 
 Creator = get_user_model()
 
-
-class CreatorSerializer(serializers.ModelSerializer):
-    phone = serializers.CharField(allow_blank=True, default="")
-    email = serializers.EmailField(allow_blank=True, default="")
+class CreatorMinimalSerializer(serializers.ModelSerializer):
     followers = serializers.SlugRelatedField(
         slug_field="id", read_only=True, many=True)
     comments = serializers.SerializerMethodField('get_profile_comments')
-    projects_count = serializers.SerializerMethodField('get_projects_count')
+    projects_count = serializers.SerializerMethodField()
     following_count = serializers.IntegerField(read_only=True)
-    dateOfBirth = serializers.DateField(read_only=True)
-    location = serializers.SlugRelatedField(
-        slug_field='name', queryset=Location.objects.all())
-    members_count = serializers.SerializerMethodField('get_members_count')
-    role = serializers.SerializerMethodField("get_role")
+    members_count = serializers.SerializerMethodField()
+    role = serializers.SerializerMethodField()
 
     class Meta:
         model = Creator
 
-        fields = ('id', 'username', 'email', 'phone', 'avatar', 'location', 'comments',
-                  'dateOfBirth', 'bio', 'followers', 'following_count', 'projects_count', 'members_count', 'role')
-
-    read_only_fields = ["id", "projects_count",
-                        "following_count", "dateOfBirth", "role"]
+        fields = [
+            "id",
+            "username",
+            "avatar",
+            "comments",
+            "bio",
+            "followers",
+            "following_count",
+            "projects_count",
+            "members_count",
+            "role"
+        ]
 
     def get_role(self, obj):
         if obj:
@@ -82,6 +83,23 @@ class CreatorSerializer(serializers.ModelSerializer):
             map(lambda x: Comment.dump_bulk(x)[0], root_comments))
 
         return parse_comment_trees(root_comments, creators_dict)
+
+
+class CreatorSerializer(CreatorMinimalSerializer):
+    phone = serializers.CharField(allow_blank=True, default="")
+    email = serializers.EmailField(allow_blank=True, default="")
+    dateOfBirth = serializers.DateField(read_only=True)
+    location = serializers.SlugRelatedField(
+        slug_field='name', queryset=Location.objects.all())
+
+    class Meta:
+        model = Creator
+
+        fields = ('id', 'username', 'email', 'phone', 'avatar', 'location', 'comments',
+                  'dateOfBirth', 'bio', 'followers', 'following_count', 'projects_count', 'members_count', 'role')
+
+    read_only_fields = ["id", "projects_count",
+                        "following_count", "dateOfBirth", "role"]
 
     def validate_email(self, email):
 

--- a/zubhub_backend/zubhub/creators/views.py
+++ b/zubhub_backend/zubhub/creators/views.py
@@ -17,7 +17,7 @@ from rest_framework.response import Response
 from rest_auth.registration.views import RegisterView
 from projects.serializers import ProjectListSerializer
 from projects.pagination import ProjectNumberPagination
-from .serializers import (CreatorSerializer, LocationSerializer, VerifyPhoneSerializer,
+from .serializers import (CreatorMinimalSerializer, CreatorSerializer, LocationSerializer, VerifyPhoneSerializer,
                           CustomRegisterSerializer, ConfirmGroupInviteSerializer, AddGroupMembersSerializer)
 from projects.serializers import CommentSerializer
 from projects.models import Comment
@@ -63,10 +63,15 @@ class UserProfileAPIView(RetrieveAPIView):
     """
 
     queryset = Creator.objects.all()
-    serializer_class = CreatorSerializer
     lookup_field = "username"
     permission_classes = [AllowAny]
     throttle_classes = [GetUserRateThrottle, SustainedRateThrottle]
+
+    def get_serializer_class(self):
+        if self.kwargs.get("username") == self.request.user.username:
+            return CreatorSerializer
+        else:
+            return CreatorMinimalSerializer
 
 
 class RegisterCreatorAPIView(RegisterView):
@@ -140,7 +145,7 @@ class CreatorSearchAPIView(ListAPIView):
     Returns paginated list of users that match the search term
     """
 
-    serializer_class = CreatorSerializer
+    serializer_class = CreatorMinimalSerializer
     permission_classes = [AllowAny]
     pagination_class = CreatorNumberPagination
     throttle_classes = [GetUserRateThrottle, SustainedRateThrottle]
@@ -250,7 +255,7 @@ class UserFollowersAPIView(ListAPIView):
     Returns list of users.
     """
 
-    serializer_class = CreatorSerializer
+    serializer_class = CreatorMinimalSerializer
     permission_classes = [AllowAny]
     throttle_classes = [GetUserRateThrottle, SustainedRateThrottle]
     pagination_class = CreatorNumberPagination
@@ -268,7 +273,7 @@ class UserFollowingAPIView(ListAPIView):
     Returns list of users.
     """
 
-    serializer_class = CreatorSerializer
+    serializer_class = CreatorMinimalSerializer
     permission_classes = [AllowAny]
     throttle_classes = [GetUserRateThrottle, SustainedRateThrottle]
     pagination_class = CreatorNumberPagination
@@ -287,7 +292,7 @@ class ToggleFollowAPIView(RetrieveAPIView):
     Returns user profile of user with provided id.
     """
 
-    serializer_class = CreatorSerializer
+    serializer_class = CreatorMinimalSerializer
     queryset = Creator.objects.all()
     permission_classes = [IsAuthenticatedOrReadOnly]
     throttle_classes = [PostUserRateThrottle, SustainedRateThrottle]
@@ -347,7 +352,7 @@ class GroupMembersAPIView(ListAPIView):
     Requires username of group. Returns list of users.
     """
 
-    serializer_class = CreatorSerializer
+    serializer_class = CreatorMinimalSerializer
     permission_classes = [AllowAny]
     throttle_classes = [GetUserRateThrottle, SustainedRateThrottle]
     pagination_class = CreatorNumberPagination
@@ -428,7 +433,7 @@ class RemoveGroupMemberAPIView(RetrieveAPIView):
     Returns profile of user removed from group.
     """
 
-    serializer_class = CreatorSerializer
+    serializer_class = CreatorMinimalSerializer
     queryset = Creator.objects.all()
     permission_classes = [IsAuthenticatedOrReadOnly]
     throttle_classes = [GetUserRateThrottle, SustainedRateThrottle]
@@ -513,4 +518,4 @@ class AddCommentAPIView(CreateAPIView):
             detect_mentions(
                 {"text": text, "profile_username": result.username, "creator": request.user.username})
 
-        return Response(CreatorSerializer(result).data, status=status.HTTP_201_CREATED)
+        return Response(CreatorMinimalSerializer(result).data, status=status.HTTP_201_CREATED)

--- a/zubhub_backend/zubhub/projects/serializers.py
+++ b/zubhub_backend/zubhub/projects/serializers.py
@@ -3,7 +3,7 @@ from django.utils.translation import ugettext_lazy as _
 from rest_framework import serializers
 from django.contrib.auth import get_user_model
 from django.conf import settings
-from creators.serializers import CreatorSerializer
+from creators.serializers import CreatorMinimalSerializer
 from .models import Project, Comment, Image, StaffPick, Category, Tag
 from projects.tasks import filter_spam_task
 from .pagination import ProjectNumberPagination
@@ -79,7 +79,7 @@ class CategorySerializer(serializers.ModelSerializer):
 
 
 class ProjectSerializer(serializers.ModelSerializer):
-    creator = CreatorSerializer(read_only=True)
+    creator = CreatorMinimalSerializer(read_only=True)
     likes = serializers.SlugRelatedField(
         many=True, slug_field='id', read_only=True)
     saved_by = serializers.SlugRelatedField(
@@ -235,7 +235,7 @@ class ProjectSerializer(serializers.ModelSerializer):
 
 
 class ProjectListSerializer(serializers.ModelSerializer):
-    creator = CreatorSerializer(read_only=True)
+    creator = CreatorMinimalSerializer(read_only=True)
     images = ImageSerializer(many=True)
     likes = serializers.SlugRelatedField(
         many=True, slug_field='id', read_only=True)


### PR DESCRIPTION
## Summary
Prior to this PR, all instance of creator model use the same CreatorSerializer. This PR created a CreatorMinimalSerializer that only exposes certain fields.

Closes #309

