### PR TITLE
Add push notification util function and use CreatorSerializer

### DIFF
--- a/zubhub_backend/zubhub/notifications/serializers.py
+++ b/zubhub_backend/zubhub/notifications/serializers.py
@@ -1,0 +1,16 @@
+from rest_framework import serializers
+
+from .models import Notification
+from creators.serializers import CreatorSerializer
+
+class NotificationSerializer(serializers.ModelSerializer):
+    recipient = CreatorSerializer(read_only=True)
+    source = CreatorSerializer(read_only=True)
+
+    class Meta:
+        model = Notification
+        fields = ('id', 'message', 'recipient', 'source', 'date')
+
+        read_only_field = [
+            'id', 'message', 'recipient', 'source', 'date'
+        ]

--- a/zubhub_backend/zubhub/notifications/utils.py
+++ b/zubhub_backend/zubhub/notifications/utils.py
@@ -1,0 +1,6 @@
+from notifications.models import Notification
+from django.utils import timezone
+
+
+def push_notification(message, recipient, source):
+    return Notification.objects.create(message=message, recipient=recipient, source=source)


### PR DESCRIPTION
## Summary

Adds push_notification function to notification utils to create notification record in the DB.

## Changes

- Add push notification function
- Use CreatorSerializer in NotificationSerializer.

**Open Question**
Should I use the new minimal creator serializer instead?