### PR TITLE
Fix search input persistence after submission

### DIFF
--- a/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
+++ b/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
@@ -46,6 +46,10 @@ import {
   closeSearchFormOrIgnore,
 } from './pageWrapperScripts';
 
+import {
+  getQueryParams
+} from './search_results/searchResultsScripts'
+
 import CustomButton from '../components/button/Button.js';
 import LoadingPage from './loading/LoadingPage';
 import * as AuthActions from '../store/actions/authActions';
@@ -175,6 +179,7 @@ function PageWrapper(props) {
                     name="q"
                     id="q"
                     type="search"
+                    defaultValue={props.location.search && getQueryParams(props.location.search).query}
                     className={clsx(
                       classes.searchFormInputStyle,
                       'search-form-input',


### PR DESCRIPTION
## Summary

Fixes a bug where the search text was not saved within the search input after submitting search
Closes #331 

## Changes

- On the search projects page, now displays the last query in the search bar

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/40071557/159834483-666b3059-7a7b-41cb-9da3-dafe796fed95.png)

After:
![image](https://user-images.githubusercontent.com/40071557/159834529-6501f3e4-f07a-4ae7-a3ac-00b737b7f18f.png)
