### PR TITLE
fixed uneven padding / spacing between icons on the video's button bar, more visible when the bar becomes horizontal.

### DIFF
--- a/zubhub_frontend/zubhub/src/assets/js/styles/components/button/buttonStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/components/button/buttonStyles.js
@@ -28,9 +28,9 @@ const styles = theme => ({
   darkDangerButtonStyle: {
     borderRadius: 30,
     backgroundColor: '#9A0036',
-    color: 'white',
+    color: 'black',
     '&:hover': {
-      color: 'white',
+      color: 'green',
       backgroundColor: '#9A0036',
     },
   },
@@ -38,7 +38,7 @@ const styles = theme => ({
     '& MuiButton-label': {
       width: '100%',
       display: 'flex',
-      justifyContent: 'flex-end',
+      justifyContent: 'space-between',
     },
   },
   customButtonStyle: {

--- a/zubhub_frontend/zubhub/src/assets/js/styles/components/project/projectStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/components/project/projectStyles.js
@@ -66,7 +66,7 @@ const styles = theme => ({
     color: '#ffcc00',
     backgroundColor: '#dc3545',
     position: 'absolute',
-    marginLeft: '1em',
+    marginLeft: '5em',
     right: '1em',
     top: '-1.8em',
     '&:hover': {
@@ -75,6 +75,7 @@ const styles = theme => ({
     },
     '& svg': {
       fill: '#ffcc00',
+
     },
     '& svg:hover': {
       fill: '#ffcc00',
@@ -112,7 +113,7 @@ const styles = theme => ({
   },
   captionStyle: {
     display: 'flex',
-    justifyContent: 'space-between',
+    justifyContent: 'space-around',
   },
   captionIconStyle: {
     display: 'flex',

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/project_details/projectDetailsStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/project_details/projectDetailsStyles.js
@@ -105,16 +105,29 @@ const styles = theme => ({
       height: '3.5em',
       width: '100%',
       flexDirection: 'row',
-      justifyContent: 'flex-start',
+      justifyContent: 'left',
     },
   },
   actionBoxButtonStyle: {
-    margin: '0.5em',
+    color: 'white',
+    margin: '1.0em',
     display: 'flex',
-    maxWidth: '100%',
-    minWidth: 0,
-    flexDirection: 'column',
-    '& span': { display: 'flex', flexDirection: 'column' },
+    maxwidth: '100%',
+    minwidth: '0',
+    textalign: 'center',
+    flexdirection: 'column',
+    justifycontent: 'left',
+    
+    
+    '& span': { 
+      display: 'inline-flex', 
+      flexDirection: 'column',
+      justifyContent:'left',
+      paddingright:'0px',
+      height:'50px',
+      width:'50px',
+      
+    },
     [theme.breakpoints.down('1080')]: {
       flexDirection: 'row',
       marginBottom: '1em',
@@ -129,6 +142,7 @@ const styles = theme => ({
     },
     '& svg': {
       fill: 'white',
+      justifyContent:'Space-arround'
     },
     '& svg:hover': {
       fill: '#F2F2F2',


### PR DESCRIPTION
## Summary
Fix #173 
Closes #173 
I changed the display to inline-flex, I gave a flex direction to column and align the items to left using justify-content which help fix the mobile horizontal view. Also for the desktop view I gave a padding-right and also height to align the contents.

## Changes
- projectDetailsstyle.js
- projectDetails.js 
- buttonStyle.js

## Screenshots
![Mobile view1](https://user-images.githubusercontent.com/70459251/161259427-3905e191-607b-4f1a-9f08-96a37d42ffdf.png)
![Mobile1](https://user-images.githubusercontent.com/70459251/161259516-f4b17142-9f77-48ab-80ab-d89c5ae5671d.png)

