### PR TITLE
improveConsistency: fixed title text small, extra vertical space ...

### DIFF
--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/project_details/projectDetailsStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/project_details/projectDetailsStyles.js
@@ -253,6 +253,9 @@ const styles = theme => ({
   error: {
     color: '#a94442',
   },
+  dialogButtonContainer: {
+    padding: '16px 24px',
+  },
 });
 
 export const sliderSettings = images_num => ({

--- a/zubhub_frontend/zubhub/src/views/project_details/ProjectDetails.jsx
+++ b/zubhub_frontend/zubhub/src/views/project_details/ProjectDetails.jsx
@@ -495,18 +495,17 @@ function ProjectDetails(props) {
             {t('projectDetails.project.delete.dialog.primary')}
             </Typography>
           </DialogTitle>
-          {delete_project_dialog_error !== null &&<Box
+          {delete_project_dialog_error !== null && (<Box
             component="p"
-            className={delete_project_dialog_error !== null && classes.errorBox}
+            className={classes.errorBox}
           >
-            {delete_project_dialog_error !== null && (
-              <Box component="span" className={classes.error}>
-                {delete_project_dialog_error}
-              </Box>
-            )}
-          </Box>}
+            <Box component="span" className={classes.error}>
+              {delete_project_dialog_error}
+            </Box>
+            
+          </Box>)}
           <DialogContent>
-            <Typography variant="subtitle1">
+            <Typography>
               {t('projectDetails.project.delete.dialog.secondary')}
             </Typography>
           </DialogContent>

--- a/zubhub_frontend/zubhub/src/views/project_details/ProjectDetails.jsx
+++ b/zubhub_frontend/zubhub/src/views/project_details/ProjectDetails.jsx
@@ -491,9 +491,11 @@ function ProjectDetails(props) {
           aria-labelledby={t('projectDetails.ariaLabels.deleteProject')}
         >
           <DialogTitle id="delete-project">
+            <Typography variant="h4">
             {t('projectDetails.project.delete.dialog.primary')}
+            </Typography>
           </DialogTitle>
-          <Box
+          {delete_project_dialog_error !== null &&<Box
             component="p"
             className={delete_project_dialog_error !== null && classes.errorBox}
           >
@@ -502,13 +504,13 @@ function ProjectDetails(props) {
                 {delete_project_dialog_error}
               </Box>
             )}
-          </Box>{' '}
+          </Box>}
           <DialogContent>
-            <Typography>
+            <Typography variant="subtitle1">
               {t('projectDetails.project.delete.dialog.secondary')}
             </Typography>
           </DialogContent>
-          <DialogActions>
+          <DialogActions className={classes.dialogButtonContainer}>
             <CustomButton
               variant="outlined"
               onClick={() =>


### PR DESCRIPTION
1. Fixed title text too small
2. removed vertical space between title and content text
3. made consistent the padding of buttons to be same as that of the title

![Screenshot from 2022-04-02 19-28-18](https://user-images.githubusercontent.com/38510556/161396456-3115e6fd-8eae-4b1b-a13f-aeb51445afa4.png)

fixes #210 
