### PR TITLE
Corrected border radius for next and prev buttons

### DIFF
--- a/zubhub_frontend/zubhub/src/assets/js/styles/components/button/buttonStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/components/button/buttonStyles.js
@@ -1,7 +1,7 @@
 const styles = theme => ({
   primaryButtonStyle: {
     backgroundColor: '#00B8C4',
-    borderRadius: '30 !important',
+    borderRadius: '30px !important',
     color: 'white',
     '&:hover': {
       backgroundColor: '#03848C',

--- a/zubhub_frontend/zubhub/src/assets/js/styles/components/button/buttonStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/components/button/buttonStyles.js
@@ -1,7 +1,7 @@
 const styles = theme => ({
   primaryButtonStyle: {
     backgroundColor: '#00B8C4',
-    borderRadius: 30,
+    borderRadius: '30 !important',
     color: 'white',
     '&:hover': {
       backgroundColor: '#03848C',


### PR DESCRIPTION
## Summary

Use same border radius for Next and Prev buttons #344

In paginated view when Prev and Next buttons are present together, their right and left border radius are zero. We need to keep consistent button styling as all other buttons. Restore the border radius for a more consistent UI experience.
