### PR TITLE
Fixed issue #372  Text wrap in login page

### DIFF
--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/login/loginStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/login/loginStyles.js
@@ -77,6 +77,7 @@ const styles = theme => ({
     alignItems: 'center',
   },
   dividerText: {
+    whiteSpace: 'nowrap',
     [theme.breakpoints.up('1600')]: {
       fontSize: '1.2rem',
     },


### PR DESCRIPTION
## Summary

closes #372

**## Changes**

added **style** -- "whiteSpace:nowrap" in the **dividerText object** in **file -- loginStyles.js**,  which was used by the  **Typography component** in the **file -- login.jsx**

  
## Screenshots

below screenshot is produced from chrome devtools

![Screenshot from 2022-04-03 16-23-18](https://user-images.githubusercontent.com/90280586/161425647-f8014cf7-4569-4abd-aa85-733b4ed3e72b.png)


