### PR TITLE
Fix issue #208: Enable scroll when menu is open on mobile and close menu on scroll 

### DIFF
--- a/zubhub_backend/zubhub/creators/views.py
+++ b/zubhub_backend/zubhub/creators/views.py
@@ -80,9 +80,12 @@ class AccountStatusAPIView(APIView):
 class UserProfileAPIView(RetrieveAPIView):
     """
     Fetch Profile of user with given username.
-
     Requires username of user.
     Returns user profile.
+
+    Note that this schema returns the full user profile, but the api sometimes
+    returns a minimal version of the user profile, omitting certain fields that
+    are not neccessary or are sensitive.
     """
 
     queryset = Creator.objects.filter(is_active=True)
@@ -91,10 +94,10 @@ class UserProfileAPIView(RetrieveAPIView):
     throttle_classes = [GetUserRateThrottle, SustainedRateThrottle]
 
     def get_serializer_class(self):
-        if self.kwargs.get("username") == self.request.user.username:
-            return CreatorSerializer
-        else:
+        if self.request and self.kwargs.get("username") != self.request.user.username:
             return CreatorMinimalSerializer
+        else:
+            return CreatorSerializer
 
 
 class RegisterCreatorAPIView(RegisterView):

--- a/zubhub_frontend/zubhub/package-lock.json
+++ b/zubhub_frontend/zubhub/package-lock.json
@@ -4203,9 +4203,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001263",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001263.tgz",
-      "integrity": "sha512-doiV5dft6yzWO1WwU19kt8Qz8R0/8DgEziz6/9n2FxUasteZNwNNYSmJO3GLBH8lCVE73AB1RPDPAeYbcO5Cvw=="
+      "version": "1.0.30001323",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001323.tgz",
+      "integrity": "sha512-e4BF2RlCVELKx8+RmklSEIVub1TWrmdhvA5kEUueummz1XyySW0DVk+3x9HyhU9MuWTa2BhqLgEuEmUwASAdCA=="
     },
     "capture-exit": {
       "version": "2.0.0",

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/login/loginStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/login/loginStyles.js
@@ -77,6 +77,7 @@ const styles = theme => ({
     alignItems: 'center',
   },
   dividerText: {
+    whiteSpace: 'nowrap',
     [theme.breakpoints.up('1600')]: {
       fontSize: '1.2rem',
     },

--- a/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
+++ b/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
@@ -74,6 +74,7 @@ function PageWrapper(props) {
   const backToTopEl = React.useRef(null);
   const classes = useStyles();
   const common_classes = useCommonStyles();
+  const trigger = useScrollTrigger()
 
   const [state, setState] = React.useState({
     username: null,
@@ -95,6 +96,10 @@ function PageWrapper(props) {
       });
   }, [props.auth.token]);
 
+  React.useEffect(()=>{
+     handleSetState(handleProfileMenuClose()) 
+  },[trigger])
+
   const handleSetState = obj => {
     if (obj) {
       Promise.resolve(obj).then(obj => {
@@ -103,15 +108,16 @@ function PageWrapper(props) {
     }
   };
 
+
   const { anchor_el, loading, open_search_form } = state;
   const { t } = props;
   const { zubhub } = props.projects;
-  const profileMenuOpen = Boolean(anchor_el);
+  const profileMenuOpen = Boolean(anchor_el); 
   return (
     <>
       <ToastContainer />
       <CssBaseline />
-      <AppBar className={classes.navBarStyle}>
+      <AppBar className={classes.navBarStyle} >
         <Container className={classes.mainContainerStyle}>
           <Toolbar className={classes.toolBarStyle}>
             <Box className={classes.logoStyle}>
@@ -131,6 +137,7 @@ function PageWrapper(props) {
               >
                 <TranslateIcon />
                 <Select
+                  disableScrollLock={true}
                   className={classes.languageSelectStyle}
                   value=""
                   onChange={e => handleChangeLanguage({ e, props })}
@@ -152,6 +159,9 @@ function PageWrapper(props) {
               >
                 <TranslateIcon />
                 <Select
+                  menuProps={{
+                    disablescrolllock: true,
+                  }}
                   className={classes.languageSelectStyle}
                   value={props.i18n.language}
                   onChange={e => handleChangeLanguage({ e, props })}
@@ -261,7 +271,9 @@ function PageWrapper(props) {
                   <Menu
                     className={common_classes.addOnSmallScreen}
                     id="menu"
+                    disableScrollLock={true}
                     anchorEl={anchor_el}
+                   
                     anchorOrigin={{
                       vertical: 'top',
                       horizontal: 'right',
@@ -343,6 +355,7 @@ function PageWrapper(props) {
                     className={classes.profileMenuStyle}
                     id="profile_menu"
                     anchorEl={anchor_el}
+                    disableScrollLock={true}
                     anchorOrigin={{
                       vertical: 'top',
                       horizontal: 'right',


### PR DESCRIPTION
## Summary
Anable scrolling when profile menu is open.   
Add scroll trigger to close menu when scrolling begins.
Closes #208,

## Changes

- Add  disableScrollLock={true} property to  small screen Menu.
- Add useEffect to closeProfileMenu when scroll triggered 


## Screenshots


![scroll anabled](https://user-images.githubusercontent.com/59707859/161431353-cee4ed05-1144-44ce-9ce6-40e680e53f1b.PNG)

