### PR TITLE
Fix issue #208: Enable scroll when menu is open and close menu on scroll

### DIFF
--- a/zubhub_frontend/zubhub/src/components/comment/Comment.jsx
+++ b/zubhub_frontend/zubhub/src/components/comment/Comment.jsx
@@ -124,6 +124,7 @@ function Comment(props) {
               <MoreVertIcon />
             </CustomButton>
             <Menu
+              disableScrollLock = {true}
               className={classes.commentMenuStyle}
               id="comment_menu"
               anchorEl={comment_menu_anchor_el}

--- a/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
+++ b/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
@@ -78,6 +78,7 @@ function PageWrapper(props) {
   const backToTopEl = React.useRef(null);
   const classes = useStyles();
   const common_classes = useCommonStyles();
+  const trigger = useScrollTrigger()
   const [searchType, setSearchType] = useState(
     getQueryParams(window.location.href).get('type') || SearchType.PROJECTS,
   );
@@ -101,6 +102,10 @@ function PageWrapper(props) {
         handleSetState({ loading: false });
       });
   }, [props.auth.token]);
+  
+  React.useEffect(()=>{
+    handleSetState(handleProfileMenuClose()) 
+  },[trigger])
 
   const handleSetState = obj => {
     if (obj) {
@@ -287,6 +292,7 @@ function PageWrapper(props) {
                   />
                   <Menu
                     className={common_classes.addOnSmallScreen}
+                    disableScrollLock={true}
                     id="menu"
                     anchorEl={anchor_el}
                     anchorOrigin={{
@@ -368,6 +374,7 @@ function PageWrapper(props) {
                   />
                   <Menu
                     className={classes.profileMenuStyle}
+                    disableScrollLock={true}
                     id="profile_menu"
                     anchorEl={anchor_el}
                     anchorOrigin={{

--- a/zubhub_frontend/zubhub/src/views/profile/Profile.jsx
+++ b/zubhub_frontend/zubhub/src/views/profile/Profile.jsx
@@ -137,6 +137,7 @@ function Profile(props) {
                   </CustomButton>
                   <Menu
                     className={classes.moreMenuStyle}
+                    disableScrollLock = {true}
                     id="profile_menu"
                     anchorEl={more_anchor_el}
                     anchorOrigin={{


### PR DESCRIPTION
## Summary
Anable scrolling when profile menu is open.   
Add scroll trigger to close menu when scrolling begins.
Closes #208,

## Changes

- Add  disableScrollLock={true} property to Menu.
- Add useEffect to closeProfileMenu when scroll triggered 


## Screenshots


![scroll anabled](https://user-images.githubusercontent.com/59707859/161431353-cee4ed05-1144-44ce-9ce6-40e680e53f1b.PNG)