### PR TITLE
fixed uneven padding / spacing between icons on the video's button bar, more visible when the bar becomes horizontal.

### DIFF
--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/project_details/projectDetailsStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/project_details/projectDetailsStyles.js
@@ -105,16 +105,29 @@ const styles = theme => ({
       height: '3.5em',
       width: '100%',
       flexDirection: 'row',
-      justifyContent: 'flex-start',
+      justifyContent: 'left',
     },
   },
   actionBoxButtonStyle: {
-    margin: '0.5em',
+    color: 'white',
+    margin: '1.0em',
     display: 'flex',
-    maxWidth: '100%',
-    minWidth: 0,
-    flexDirection: 'column',
-    '& span': { display: 'flex', flexDirection: 'column' },
+    maxwidth: '100%',
+    minwidth: '0',
+    textalign: 'center',
+    flexdirection: 'column',
+    justifycontent: 'left',
+    
+    
+    '& span': { 
+      display: 'inline-flex', 
+      flexDirection: 'column',
+      justifyContent:'left',
+      paddingright:'0px',
+      height:'50px',
+      width:'50px',
+      
+    },
     [theme.breakpoints.down('1080')]: {
       flexDirection: 'row',
       marginBottom: '1em',
@@ -128,7 +141,7 @@ const styles = theme => ({
       color: '#F2F2F2',
     },
     '& svg': {
-      fill: 'white',
+      fill: 'white'
     },
     '& svg:hover': {
       fill: '#F2F2F2',


### PR DESCRIPTION
## Summary
Fix #173 
Closes #173 
I changed the display to inline-flex, I gave a flex direction to column and align the items to left using justify-content which help fix the mobile horizontal view. Also for the desktop view I gave a padding-right and also height to align the contents.

## Changes
- projectDetailsstyle.js


## Screenshots
![mob](https://user-images.githubusercontent.com/70459251/163752740-dffea50d-1a54-49ce-8ee8-131691a5edba.png)
![161259516-f4b17142-9f77-48ab-80ab-d89c5ae5671d](https://user-images.githubusercontent.com/70459251/163752800-65aa3e45-56c3-4062-8cd4-8daa8548e170.png)
![tab](https://user-images.githubusercontent.com/70459251/163752842-7aa434ae-2505-48a0-a502-0d30823dd890.png)

