### PR TITLE
Fix issue #207 : Change login welcome msg color and make it bolder

### DIFF
--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/login/loginStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/login/loginStyles.js
@@ -22,9 +22,11 @@ const styles = theme => ({
     color: 'white',
     padding: '0 30px',
   },
-  ttitleStyle: {
-    fontWeight: 900,
-    fontSize: '1.7rem',
+  titleStyle: {
+    fontWeight: 990,
+    color: '#fbd22c',
+    textShadow: '2px 2px 2px black, 0 3px 2px black, 0 0 1px white, 0 0 2px white',
+    fontSize: '1.6rem',
     [theme.breakpoints.up('1600')]: {
       fontSize: '2.5rem',
     },


### PR DESCRIPTION
## Summary

Improve the UX on login page by making "Welcome to Zubhub" bolder and Changing it's color.
Closes #207

## Changes

- Increase text Weight add color and text Shadow to login title style class.

## Screenshots

![login title yellow](https://user-images.githubusercontent.com/59707859/163798049-237d0b71-e015-4fd5-b2d0-110a4099b3ba.PNG)
