### PR TITLE
Fixing failing CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,5 +12,5 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material 
+      - run: cd docs && pip install mkdocs-material 
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
## Summary
This pr updates the command to deploy the docs (in `ci.yml`) to move to the directory where the config file exists.
The config file exists in `docs/`
Closes #464 