### PR TITLE
Display project uploaded  image preview

### DIFF
--- a/zubhub_frontend/zubhub/public/index.html
+++ b/zubhub_frontend/zubhub/public/index.html
@@ -47,6 +47,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Zubhub</title>
+    <script src="https://kit.fontawesome.com/58aa8d2b83.js" crossorigin="anonymous"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/create_project/createProjectStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/create_project/createProjectStyles.js
@@ -9,6 +9,13 @@ const styles = theme => ({
     background:
       'linear-gradient(to bottom, rgba(255,204,0,1) 0%, rgba(255,229,133,1) 25%, rgba(255,255,255,1) 61%, rgba(255,255,255,1) 100%)',
   },
+  imagePreview:{
+    width: '100%',
+    height: '100%',
+  },
+  imagePreviewContainer:{
+    height: '130px',
+  },
   containerStyle: {
     maxWidth: '600px',
     [theme.breakpoints.up('1600')]: {

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/create_project/createProjectStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/create_project/createProjectStyles.js
@@ -11,10 +11,21 @@ const styles = theme => ({
   },
   imagePreview:{
     width: '100%',
+    position: 'absolute',
     height: '100%',
+    top: 0,
+    borderRadius: '15px 0px 15px 15px',
   },
   imagePreviewContainer:{
-    height: '130px',
+    position: 'relative',
+    paddingTop: '100%',
+    borderRadius: '15px 0px 15px 15px',
+  },
+  closeIcon:{
+    position: 'absolute',
+    top: -5,
+    right: -10,
+    color: 'red',
   },
   containerStyle: {
     maxWidth: '600px',

--- a/zubhub_frontend/zubhub/src/views/create_project/CreateProject.jsx
+++ b/zubhub_frontend/zubhub/src/views/create_project/CreateProject.jsx
@@ -68,6 +68,7 @@ import {
   handlePublishFieldBlur,
   checkMediaFilesErrorState,
   handleSelectVideoFileChecked,
+  removeUploadedImage,
 } from './createProjectScripts';
 
 import * as ProjectActions from '../../store/actions/projectActions';
@@ -480,7 +481,7 @@ function CreateProject(props) {
                         <Grid container spacing={2}>
                          {
                          media_upload.images_to_upload.map((image) =>
-                            <Grid item key={image.name} md={4} xs={12} sm={6}>
+                            <Grid item key={image.name} md={4} xs={6} sm={6}>
                               <Paper key={[image.name,'paper'].join('')}
                                    className={classes.imagePreviewContainer}
                               >
@@ -488,6 +489,9 @@ function CreateProject(props) {
                                    className={classes.imagePreview} 
                                    src={window.URL.createObjectURL(image)} 
                                    alt={image.name}/>
+                                   <i className={"fas fa-times-circle "+classes.closeIcon} 
+                                      onClick={e => handleSetState(removeUploadedImage(image,media_upload)) }
+                                   ></i>
                               </Paper>
                             </Grid>
                              )

--- a/zubhub_frontend/zubhub/src/views/create_project/CreateProject.jsx
+++ b/zubhub_frontend/zubhub/src/views/create_project/CreateProject.jsx
@@ -19,6 +19,7 @@ import MovieIcon from '@material-ui/icons/Movie';
 import InsertLinkIcon from '@material-ui/icons/InsertLink';
 import {
   Grid,
+  Paper,
   Box,
   Container,
   Card,
@@ -474,6 +475,27 @@ function CreateProject(props) {
                                 `createProject.inputs.projectImages.errors.${props.errors['project_images']}`,
                               ))}
                         </FormHelperText>
+
+                        {(media_upload.images_to_upload.length > 0) && 
+                        <Grid container spacing={2}>
+                         {
+                         media_upload.images_to_upload.map((image) =>
+                            <Grid item key={image.name} md={4} xs={12} sm={6}>
+                              <Paper key={[image.name,'paper'].join('')}
+                                   className={classes.imagePreviewContainer}
+                              >
+                                <img
+                                   className={classes.imagePreview} 
+                                   src={window.URL.createObjectURL(image)} 
+                                   alt={image.name}/>
+                              </Paper>
+                            </Grid>
+                             )
+                         }
+                        </Grid>
+                        }
+                        
+                         
                       </FormControl>
                     </Grid>
 

--- a/zubhub_frontend/zubhub/src/views/create_project/createProjectScripts.js
+++ b/zubhub_frontend/zubhub/src/views/create_project/createProjectScripts.js
@@ -73,6 +73,11 @@ export const vars = {
   },
 };
 
+export const removeUploadedImage = (image, media_upload) =>{
+  let new_media_upload = {...media_upload, images_to_upload: media_upload.images_to_upload.filter(img => img !== image)}
+  return {media_upload: new_media_upload}
+};
+
 /**
  * @function getCategories
  * @author Raymond Ndibe <ndiberaymond1@gmail.com>


### PR DESCRIPTION
## Summary

Display preview of project images that a user uploads in create project form.
Closes #164

## Changes

- Add Grid container  and Paper components to display uploaded images.
- Make Grid items responsive to screen size.

## Screenshots
![preview md](https://user-images.githubusercontent.com/59707859/169126675-c70a01a9-7a99-42a3-9c50-4ca4084869a9.PNG)
![preview xs](https://user-images.githubusercontent.com/59707859/169126700-1cbcd161-dbb6-419b-966b-b24cbbf68c9d.PNG)

