### PR TITLE
fix comment username link

### DIFF
--- a/zubhub_frontend/zubhub/src/components/comment/Comment.jsx
+++ b/zubhub_frontend/zubhub/src/components/comment/Comment.jsx
@@ -86,7 +86,7 @@ function Comment(props) {
             common_classes.textDecorationNone,
             !parent ? classes.commentMetaStyle : classes.subCommentMetaStyle,
           )}
-          to={`/creators/${props.auth.username}`}
+          to={`/creators/${comment.creator.username}`}
         >
           <Avatar
             className={


### PR DESCRIPTION
## Summary
**Before:**  Clicking on a comment creator's username opens the logged in user's profile.  

**Now:** Clicking the username in comments opens the comment creator's profile as it should.

Issue's full description: #438 
Closes #438 

## Changes
Username link in the comment box sourced the username from 'auth' instead of 'comment' prop, which caused the issue. 
Changed the source of username in the url path from `props.auth.username` to `props.comment.creator.username`, which fixed it.