### PR TITLE
Browse activity button gets merged search bar

### DIFF
--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/page_wrapper/pageWrapperStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/page_wrapper/pageWrapperStyles.js
@@ -14,6 +14,9 @@ const styles = theme => ({
   },
   logoStyle: {
     flexGrow: 1,
+    display: 'flex',
+    alignItems: 'center',
+    flexWrap: 'wrap',
     '& img': {
       height: '2em',
     },
@@ -60,7 +63,7 @@ const styles = theme => ({
         width: '100%',
       },
       [theme.breakpoints.down('1054')]: {
-        width: '20em',
+        // width: '20em',
       },
     },
   },
@@ -119,12 +122,13 @@ const styles = theme => ({
     color: 'white',
   },
   addOn894: {
-    [theme.breakpoints.up('894')]: {
+    [theme.breakpoints.up('1168')]: {
       display: 'none',
     },
   },
   removeOn894: {
-    [theme.breakpoints.down('894')]: {
+    flex: 1,
+    [theme.breakpoints.down('1168')]: {
       display: 'none',
     },
   },

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/page_wrapper/pageWrapperStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/page_wrapper/pageWrapperStyles.js
@@ -31,7 +31,6 @@ const styles = theme => ({
     '& .search-form-input': {
       height: '2.5em',
       maxWidth: '40em',
-      width: '35em',
       backgroundColor: 'rgba(255,255,255,0.2)',
       color: 'black',
       borderRadius: '50px',
@@ -58,7 +57,7 @@ const styles = theme => ({
         },
       },
       [theme.breakpoints.down('1216')]: {
-        width: '30em',
+        width: '100%',
       },
       [theme.breakpoints.down('1054')]: {
         width: '20em',

--- a/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
+++ b/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
@@ -278,7 +278,7 @@ function PageWrapper(props) {
                 onSubmit={handleSubmit}
                 ref={formRef}
               >
-                <FormControl variant="outlined">
+                <FormControl className={clsx(common_classes.width100Percent, common_classes.displayFlex, common_classes.displayInlineFlex)} variant="outlined">
                   <InputLabel
                     htmlFor="q"
                     className={classes.searchFormLabelStyle}
@@ -302,6 +302,7 @@ function PageWrapper(props) {
                       </InputSelect>
                     </FormControl>
                     <Autocomplete
+                      style={{ width: '70%' }}
                       options={options}
                       defaultValue={{
                         title:

--- a/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
+++ b/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
@@ -145,8 +145,8 @@ function PageWrapper(props) {
   useEffect(() => {
     throttledFetchOptions(
       query ||
-        (props.location.search &&
-          getQueryParams(window.location.href).get('q')),
+      (props.location.search &&
+        getQueryParams(window.location.href).get('q')),
       searchType,
     );
   }, [query, searchType]);
@@ -615,39 +615,39 @@ function PageWrapper(props) {
                     {props.auth.tags.filter(
                       tag => tag === 'staff' || tag === 'educator',
                     ).length > 0 && (
-                      <MenuItem
-                        className={clsx(common_classes.removeOnSmallScreen)}
-                        onClick={() => {
-                          history.push('/activities', { flag: 'educator' });
-                        }}
-                      >
-                        <Typography
-                          variant="subtitle2"
-                          color="textPrimary"
-                          component="span"
+                        <MenuItem
+                          className={clsx(common_classes.removeOnSmallScreen)}
+                          onClick={() => {
+                            history.push('/activities', { flag: 'educator' });
+                          }}
                         >
-                          {t('pageWrapper.navbar.myActivities')}
-                        </Typography>
-                      </MenuItem>
-                    )}
+                          <Typography
+                            variant="subtitle2"
+                            color="textPrimary"
+                            component="span"
+                          >
+                            {t('pageWrapper.navbar.myActivities')}
+                          </Typography>
+                        </MenuItem>
+                      )}
                     {props.auth.tags.filter(
                       tag => tag === 'staff' || tag === 'moderator',
                     ).length > 0 && (
-                      <MenuItem
-                        className={clsx(common_classes.removeOnSmallScreen)}
-                        onClick={() => {
-                          history.push('/activities', { flag: 'staff' });
-                        }}
-                      >
-                        <Typography
-                          variant="subtitle2"
-                          color="textPrimary"
-                          component="span"
+                        <MenuItem
+                          className={clsx(common_classes.removeOnSmallScreen)}
+                          onClick={() => {
+                            history.push('/activities', { flag: 'staff' });
+                          }}
                         >
-                          {t('pageWrapper.navbar.unpublishedActivities')}
-                        </Typography>
-                      </MenuItem>
-                    )}
+                          <Typography
+                            variant="subtitle2"
+                            color="textPrimary"
+                            component="span"
+                          >
+                            {t('pageWrapper.navbar.unpublishedActivities')}
+                          </Typography>
+                        </MenuItem>
+                      )}
                     <MenuItem>
                       <Link
                         className={classes.textDecorationNone}
@@ -751,6 +751,7 @@ function PageWrapper(props) {
                     {t('pageWrapper.inputs.search.label')}
                   </InputLabel>
                   <Autocomplete
+                    style={{ width: '100%' }}
                     options={options}
                     defaultValue={
                       props.location.search &&


### PR DESCRIPTION
## Summary
- On Desktop screens, changed the navbar search input field to always look good
- On Mobile, made the search input to always be centered and never overflow to the right end of the screen
Description of PR here...
Closes #580

## Changes

- modified the style of the search bar in the navbar

## Screenshots

(Insert image, only for frontend)
<img width="1413" alt="image" src="https://user-images.githubusercontent.com/57509871/223539838-2a2a2441-4548-43b3-9a0c-dbbb8374ae60.png">
<img width="1413" alt="image" src="https://user-images.githubusercontent.com/57509871/223539939-2f4eeada-8f65-48bb-93ad-15b6efe5b03d.png">
<img width="1413" alt="image" src="https://user-images.githubusercontent.com/57509871/223539714-a8ca5dfe-c8e8-47b3-a1df-42cc6dcac2f3.png">
<img width="1413" alt="image" src="https://user-images.githubusercontent.com/57509871/223540050-99a9d7b6-3c04-4029-a3bb-7199a607969e.png">



