### PR TITLE
Fixed inconsistent padding issue on navbar

### DIFF
--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/page_wrapper/pageWrapperStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/page_wrapper/pageWrapperStyles.js
@@ -2,6 +2,13 @@ const styles = theme => ({
   navBarStyle: {
     backgroundColor: '#DC3545',
   },
+  input: {
+    flex: 1,
+    marginRight: '2rem',
+  },
+  customButton: {
+    fontSize: '1.15rem',
+  },
   mainContainerStyle: {
     maxWidth: '2000px',
     zIndex: 1,
@@ -9,8 +16,7 @@ const styles = theme => ({
       '0px 2px 4px -1px rgb(0 0 0 / 20%), 0px 4px 5px 0px rgb(0 0 0 / 14%), 0px 1px 10px 0px rgb(0 0 0 / 12%)',
   },
   toolBarStyle: {
-    paddingLeft: 0,
-    paddingRight: 0,
+    padding: '15px 0',
   },
   logoStyle: {
     flexGrow: 1,
@@ -149,8 +155,8 @@ const styles = theme => ({
     cursor: 'pointer',
     backgroundColor: 'white',
     [theme.breakpoints.up('1600')]: {
-      height: '3em',
-      width: '3em',
+      height: '40px',
+      width: '40px',
     },
   },
   profileMenuStyle: {

--- a/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
+++ b/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
@@ -302,7 +302,7 @@ function PageWrapper(props) {
                       </InputSelect>
                     </FormControl>
                     <Autocomplete
-                      style={{ width: '70%' }}
+                      className={classes.input}
                       options={options}
                       defaultValue={{
                         title:
@@ -481,7 +481,7 @@ function PageWrapper(props) {
                           variant="contained"
                           primaryButtonStyle
                           primaryButtonStyle2
-                          customButtonStyle
+                          className={classes.customButton}
                           size="small"
                         >
                           {t('pageWrapper.navbar.createActivity')}
@@ -501,7 +501,7 @@ function PageWrapper(props) {
                         variant="contained"
                         primaryButtonStyle
                         primaryButtonStyle2
-                        customButtonStyle
+                        className={classes.customButton}
                         size="small"
                       >
                         {t('pageWrapper.navbar.browseActivities')}
@@ -519,7 +519,7 @@ function PageWrapper(props) {
                     <CustomButton
                       variant="contained"
                       primaryButtonStyle
-                      customButtonStyle
+                      className={classes.customButton}
                       size="small"
                     >
                       {t('pageWrapper.navbar.createProject')}


### PR DESCRIPTION
## Summary

Description of PR here:
This PR consists of making the padding across the navbar consistent
Closes #588

## Changes

- Added padding of 15px to the navbar 
- Gave a static width and height of 40px to avatar
- Slightly reduced the font-size of the activity and project buttons

## Screenshots
<img width="1540" alt="image" src="https://user-images.githubusercontent.com/57509871/223880279-71483237-973d-45fb-842f-668e05bb21bf.png">
<img width="1540" alt="image" src="https://user-images.githubusercontent.com/57509871/223880327-00fe4683-cd6e-4674-b001-74a976345988.png">
<img width="1540" alt="image" src="https://user-images.githubusercontent.com/57509871/223880389-9188ab17-146d-489e-83eb-51e43c11a796.png">
<img width="1540" alt="image" src="https://user-images.githubusercontent.com/57509871/223880678-af42ffb6-1230-45b0-8f94-a0d70138ea79.png">
<img width="1540" alt="image" src="https://user-images.githubusercontent.com/57509871/223880487-185a6714-dfc9-4e27-9e48-668b5f493928.png">
<img width="1540" alt="image" src="https://user-images.githubusercontent.com/57509871/223880777-0a60e3b8-5e7e-42da-a1ed-9c8ac461b230.png">

