### PR TITLE
Prevent input submit when input field is empty

### DIFF
--- a/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
+++ b/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
@@ -200,6 +200,7 @@ function PageWrapper(props) {
 
   const handleSubmit = e => {
     e.preventDefault();
+    if (query.length == 0) return
     const queryParams = new URLSearchParams({
       type: searchType,
       q: query,


### PR DESCRIPTION
## Summary

Description of PR
This PR is to prevent the Input field in the navbar from getting submitted when empty.
Closes #595

## Changes

- added an if statement in the submit function to check `query.length` and break out of the function if `=0`
