### PR TITLE
Made the active language visible on the footer language dropdown on mobile

### DIFF
--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/page_wrapper/pageWrapperStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/page_wrapper/pageWrapperStyles.js
@@ -212,6 +212,9 @@ const styles = theme => ({
     '&.MuiInput-underline:after': {
       display: 'none !important',
     },
+    '& .MuiSelect-icon': {
+      color: 'white',
+    },
     '& .MuiSelect-root': {
       boxSizing: 'border-box',
       backgroundColor: 'rgba(0,0,0,0)',

--- a/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
+++ b/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
@@ -832,29 +832,8 @@ function PageWrapper(props) {
                 classes.languageSelectBoxStyle,
                 common_classes.displayInlineFlex,
                 common_classes.alignCenter,
-                common_classes.addOnSmallScreen,
               )}
-            >
-              <TranslateIcon />
-              <Select
-                className={classes.languageSelectStyle}
-                value=""
-                onChange={e => handleChangeLanguage({ e, props })}
-              >
-                {Object.keys(languageMap).map((ln, index) => (
-                  <MenuItem key={index} value={ln}>
-                    {languageMap[ln]}
-                  </MenuItem>
-                ))}
-              </Select>
-            </Box>
-            <Box
-              className={clsx(
-                classes.languageSelectBoxStyle,
-                common_classes.displayInlineFlex,
-                common_classes.alignCenter,
-                common_classes.removeOnSmallScreen,
-              )}
+              style={{ margin: 0 }}
             >
               <TranslateIcon />
               <Select


### PR DESCRIPTION
## Summary

Description of PR: 
This PR makes visible the selected language on smaller screens and also changes the language select dropdown icon color to white
Closes #589

## Changes

- Removed the code that was responsible for not showing the selected language in the footer.
- Changed the color of the dropdown icon to white


## Screenshots
<img width="354" alt="image" src="https://user-images.githubusercontent.com/57509871/223862578-80150fda-d489-4562-b596-28bf8740ffa0.png">
