### PR TITLE
Feature to change email and phone

### DIFF
--- a/zubhub_backend/zubhub/creators/serializers.py
+++ b/zubhub_backend/zubhub/creators/serializers.py
@@ -111,10 +111,6 @@ class CreatorSerializer(CreatorMinimalSerializer):
             raise serializers.ValidationError(
                 _("a user with that email address already exists"))
 
-        # if (self.context.get("request").user.email):
-        #     raise serializers.ValidationError(
-        #         _("to edit this field mail hello@unstructured.studio"))
-
         return email
 
     def validate_phone(self, phone):
@@ -132,10 +128,6 @@ class CreatorSerializer(CreatorMinimalSerializer):
                 return phone
             raise serializers.ValidationError(
                 _("a user with that phone number already exists"))
-
-        # if (self.context.get("request").user.phone):
-        #     raise serializers.ValidationError(
-        #         _("to edit this field mail hello@unstructured.studio"))
 
         return phone
 

--- a/zubhub_backend/zubhub/creators/serializers.py
+++ b/zubhub_backend/zubhub/creators/serializers.py
@@ -111,9 +111,9 @@ class CreatorSerializer(CreatorMinimalSerializer):
             raise serializers.ValidationError(
                 _("a user with that email address already exists"))
 
-        if (self.context.get("request").user.email):
-            raise serializers.ValidationError(
-                _("to edit this field mail hello@unstructured.studio"))
+        # if (self.context.get("request").user.email):
+        #     raise serializers.ValidationError(
+        #         _("to edit this field mail hello@unstructured.studio"))
 
         return email
 
@@ -133,9 +133,9 @@ class CreatorSerializer(CreatorMinimalSerializer):
             raise serializers.ValidationError(
                 _("a user with that phone number already exists"))
 
-        if (self.context.get("request").user.phone):
-            raise serializers.ValidationError(
-                _("to edit this field mail hello@unstructured.studio"))
+        # if (self.context.get("request").user.phone):
+        #     raise serializers.ValidationError(
+        #         _("to edit this field mail hello@unstructured.studio"))
 
         return phone
 

--- a/zubhub_backend/zubhub/creators/views.py
+++ b/zubhub_backend/zubhub/creators/views.py
@@ -221,8 +221,8 @@ class EditCreatorAPIView(UpdateAPIView):
     request body format:\n
         {\n
             "username": "string",\n
-            "email": "",\n
-            "phone": "",\n
+            "email": "string",\n
+            "phone": "string",\n
             "avatar": "string",\n
             "location": "string",\n
             "bio": "string"\n

--- a/zubhub_frontend/zubhub/public/locales/en/translation.json
+++ b/zubhub_frontend/zubhub/public/locales/en/translation.json
@@ -623,6 +623,13 @@
           "tooLong": "Looks like you have a lot to say! But we don't support more than 255 characters for now :("
         }
       },
+      "password": {
+        "label": "Current Password",
+        "errors": {
+          "invalid": "You have entered incorrect password",
+          "required": "Seems like you forgot this"
+        }
+      },
       "submit": "Edit Profile"
     },
     "or": "OR",

--- a/zubhub_frontend/zubhub/src/views/edit_profile/EditProfile.jsx
+++ b/zubhub_frontend/zubhub/src/views/edit_profile/EditProfile.jsx
@@ -10,6 +10,11 @@ import { withFormik } from 'formik';
 import { toast } from 'react-toastify';
 
 import { makeStyles } from '@material-ui/core/styles';
+
+import Visibility from '@material-ui/icons/Visibility';
+
+import VisibilityOff from '@material-ui/icons/VisibilityOff';
+
 import {
   Grid,
   Box,
@@ -31,6 +36,8 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  InputAdornment,
+  IconButton,
 } from '@material-ui/core';
 
 import {
@@ -42,6 +49,8 @@ import {
   handleTooltipClose,
   handleToggleDeleteAccountModal,
   deleteAccount,
+  handleClickShowPassword,
+  handleMouseDownPassword,
 } from './editProfileScripts';
 
 import CustomButton from '../../components/button/Button';
@@ -73,6 +82,7 @@ function EditProfile(props) {
     tool_tip_open: false,
     dialog_error: null,
     open_delete_account_modal: false,
+    show_password: false,
   });
 
   React.useEffect(() => {
@@ -81,6 +91,7 @@ function EditProfile(props) {
   }, []);
 
   const classes = useStyles();
+  const { show_password } = state;
 
   const handleSetState = obj => {
     if (obj) {
@@ -285,11 +296,7 @@ function EditProfile(props) {
                       </InputLabel>
                       <OutlinedInput
                         ref={refs.email_el}
-                        disabled={
-                          props.status && props.status['init_email']
-                            ? true
-                            : false
-                        }
+                        
                         className={clsx(classes.customInputStyle)}
                         id="email"
                         name="email"
@@ -302,28 +309,6 @@ function EditProfile(props) {
                           document,
                         )}
                       />
-                      <FormHelperText
-                        className={classes.fieldHelperTextStyle}
-                        error
-                      >
-                        {props.status && props.status['init_email'] && (
-                          <Typography
-                            color="textSecondary"
-                            variant="caption"
-                            component="span"
-                            className={classes.fieldHelperTextStyle}
-                          >
-                            {t('editProfile.inputs.email.disabledHelperText')}
-                          </Typography>
-                        )}
-                        <br />
-                        {(props.status && props.status['email']) ||
-                          (props.touched['email'] &&
-                            props.errors['email'] &&
-                            t(
-                              `editProfile.inputs.email.errors.${props.errors['email']}`,
-                            ))}
-                      </FormHelperText>
                     </FormControl>
                   </Grid>
 
@@ -347,11 +332,7 @@ function EditProfile(props) {
                       </InputLabel>
                       <OutlinedInput
                         ref={refs.phone_el}
-                        disabled={
-                          props.status && props.status['init_phone']
-                            ? true
-                            : false
-                        }
+                        
                         className={clsx(classes.customInputStyle)}
                         id="phone"
                         name="phone"
@@ -364,26 +345,66 @@ function EditProfile(props) {
                           document,
                         )}
                       />
+                    </FormControl>
+                  </Grid>
+
+                  <Grid item xs={12} sm={6} md={6}>
+                    <FormControl
+                      className={clsx(classes.margin, classes.textField)}
+                      variant="outlined"
+                      size="small"
+                      fullWidth
+                      margin="normal"
+                      error={
+                        (props.status && props.status['password']) ||
+                        (props.touched['password'] && props.errors['password'])
+                      }
+                    >
+                      <InputLabel
+                        className={classes.customLabelStyle}
+                        htmlFor="password"
+                      >
+                        {t('editProfile.inputs.password.label')}
+                      </InputLabel>
+                      <OutlinedInput
+                        className={classes.customInputStyle}
+                        id="password"
+                        name="password"
+                        type={show_password ? 'text' : 'password'}
+                        onChange={props.handleChange}
+                        onBlur={props.handleBlur}
+                        endAdornment={
+                          <InputAdornment position="end">
+                            <IconButton
+                              aria-label="toggle password visibility"
+                              onClick={() =>
+                                handleSetState(handleClickShowPassword(state))
+                              }
+                              onMouseDown={handleMouseDownPassword}
+                              edge="end"
+                            >
+                              {show_password ? (
+                                <Visibility />
+                              ) : (
+                                <VisibilityOff />
+                              )}
+                            </IconButton>
+                          </InputAdornment>
+                        }
+                        labelWidth={calculateLabelWidth(
+                          t('editProfile.inputs.password.label'),
+                          document,
+                        )}
+                      />
                       <FormHelperText
                         className={classes.fieldHelperTextStyle}
                         error
                       >
-                        {props.status && props.status['init_phone'] && (
-                          <Typography
-                            color="textSecondary"
-                            variant="caption"
-                            component="span"
-                            className={classes.fieldHelperTextStyle}
-                          >
-                            {t('editProfile.inputs.phone.disabledHelperText')}
-                          </Typography>
-                        )}
-                        <br />
-                        {(props.status && props.status['phone']) ||
-                          (props.touched['phone'] &&
-                            props.errors['phone'] &&
+                        {(props.status && props.status['password']) ||
+                          (props.touched['password'] &&
+                            props.errors['password'] &&
                             t(
-                              `editProfile.inputs.phone.errors.${props.errors['phone']}`,
+                              `editProfile.inputs.password.errors.${props.errors['password']}`,
                             ))}
                       </FormHelperText>
                     </FormControl>
@@ -588,6 +609,7 @@ EditProfile.propTypes = {
   editUserProfile: PropTypes.func.isRequired,
   getLocations: PropTypes.func.isRequired,
   deleteAccount: PropTypes.func.isRequired,
+  login: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = state => {
@@ -610,6 +632,9 @@ const mapDispatchToProps = dispatch => {
     deleteAccount: args => {
       return dispatch(AuthActions.deleteAccount(args));
     },
+    login: args => {
+      return dispatch(AuthActions.login(args));
+    },
     logout: args => {
       return dispatch(AuthActions.logout(args));
     },
@@ -623,6 +648,9 @@ export default connect(
   withFormik({
     mapPropsToValue: () => ({
       username: '',
+      email:'',
+      phone:'',
+      password: '',
       user_location: '',
       bio: '',
     }),

--- a/zubhub_frontend/zubhub/src/views/edit_profile/editProfileScripts.js
+++ b/zubhub_frontend/zubhub/src/views/edit_profile/editProfileScripts.js
@@ -141,6 +141,7 @@ export const editProfile = (e, props, toast) => {
                   server_errors['user_location'] = messages[key][0];
                 } else {
                   server_errors[key] = messages[key][0];
+                  toast.error(server_errors[key]);
                 }
               });
               // props.setStatus({

--- a/zubhub_frontend/zubhub/src/views/edit_profile/editProfileScripts.js
+++ b/zubhub_frontend/zubhub/src/views/edit_profile/editProfileScripts.js
@@ -115,11 +115,14 @@ export const editProfile = (e, props, toast) => {
     props.validateField('editProfile.inputs.password.errors');
   } else {
     props.login({ values: props.values, history: props.history }).catch(error => {
-      const messages = JSON.parse(error.message);
-      console.log(messages);
-      toast.error(props.t('editProfile.inputs.password.errors.invalid'));
-      password_match = false;
-      return;
+      try{
+        const messages = JSON.parse(error.message);
+        toast.error(props.t('editProfile.inputs.password.errors.invalid'));
+        password_match = false;
+        return;
+      } catch (err) {
+        toast.error(props.t('err.message'));
+      }
     }).finally(() => {
       if (password_match == false) {
         return;
@@ -144,12 +147,6 @@ export const editProfile = (e, props, toast) => {
                   toast.error(server_errors[key]);
                 }
               });
-              // props.setStatus({
-              //   //this is a hack. we need to find a more react way of maintaining initial state for email and phone.
-              //   init_email: props.status && props.status.init_email,
-              //   init_phone: props.status && props.status.init_phone,
-              //   ...server_errors,
-              // });
             } else {
               props.setStatus({
                 non_field_errors: props.t('editProfile.errors.unexpected'),


### PR DESCRIPTION
## Summary

Allow email address and phone number to be changed
Closes #198 

## Changes

- Few changes to serializers in backend to accept change of email & phone
- Changes in frontend to implement the feature (new password field and editable phone & email fields)
- Made use of the existing login function to verify the current user and make changes accordingly

## Things to note:
I was wondering how directly exposing the backend to accept changes would not create a security issue as anyone can hit the api, and I tried the same. So, that scenario is handled by authorization token which is unique for each user.

## Screenshots
![image](https://user-images.githubusercontent.com/43777817/224430274-6d8c080a-0474-46c3-9eff-b94bf07019ef.png)
![image](https://user-images.githubusercontent.com/43777817/224430338-014d8b42-5e30-456b-ab0e-c8349ce0003f.png)

Second commit was done to show the error message of existing email/phone like this:
![image](https://user-images.githubusercontent.com/43777817/224463946-ccace2bc-98d3-46c7-9e6f-393de72481b2.png)
