### PR TITLE
Fix footer links

### DIFF
--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/page_wrapper/pageWrapperStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/page_wrapper/pageWrapperStyles.js
@@ -261,7 +261,7 @@ const styles = theme => ({
     color: 'white',
     cursor: 'pointer',
     '&:hover': {
-      color: 'rgb(254 211 42)',
+      color: 'rgb(243 137 147)',
     },
   }, 
    center: {

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/page_wrapper/pageWrapperStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/page_wrapper/pageWrapperStyles.js
@@ -263,9 +263,8 @@ const styles = theme => ({
     '&:hover': {
       color: 'rgb(254 211 42)',
     },
-  },
-
-  center: {
+  }, 
+   center: {
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/page_wrapper/pageWrapperStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/page_wrapper/pageWrapperStyles.js
@@ -259,7 +259,12 @@ const styles = theme => ({
   },
   footerLinkStyle: {
     color: 'white',
+    cursor: 'pointer',
+    '&:hover': {
+      color: 'rgb(254 211 42)',
+    },
   },
+
   center: {
     display: 'flex',
     justifyContent: 'center',


### PR DESCRIPTION
## Summary

This PR adds some styling to make the footer links change color on hover. The `footerLinkStyle` class has been updated with the following properties:

```javascript
footerLinkStyle: {
  color: 'white',
  cursor: 'pointer',
  '&:hover': {
    color: 'rgb(254 211 42)',
  },
},

```
This will change the color of the links when the mouse is hovering over them.

Fixes #625

## Changes

-   Updated `footerLinkStyle` class to change link color on hover.
## Screenshots
![image](https://user-images.githubusercontent.com/29153968/224454252-196dfe38-26de-498e-8670-0a06c66cb0a7.png)

