### PR TITLE
Cannot go to previous from our profile page after clicking on the our username on a project that we created

### DIFF
--- a/zubhub_frontend/zubhub/src/views/profile/profileScripts.js
+++ b/zubhub_frontend/zubhub/src/views/profile/profileScripts.js
@@ -11,7 +11,7 @@ import { getUserDrafts } from '../../store/actions/projectActions';
 
   if (!username) {
     username = props.auth.username;
-  } else if (props.auth.username === username) props.history.push('/profile');
+  } else if (props.auth.username === username) props.history.replace('/profile');
   return props.getUserProfile({
     username,
     token: props.auth.token,
@@ -51,14 +51,14 @@ export const updateProjects = (res, projects, props, toast) => {
   return res
     .then(res => {
       if (res.project && res.project.title) {
-        if(projects[0]){
+        if (projects[0]) {
           projects = projects.map(project =>
             project.id === res.project.id ? res.project : project,
           );
         } else {
-        projects = projects.results.map(project =>
-          project.id === res.project.id ? res.project : project,
-        );
+          projects = projects.results.map(project =>
+            project.id === res.project.id ? res.project : project,
+          );
         }
         return { results: projects };
       } else {


### PR DESCRIPTION
## Summary

Description of PR
This PR enables the user to go back to their previous page after clicking on the their username on the project card they created.

Closes #634 

## Changes

- updated` history.push` with` history.replace` in getUserProfile script

## Screenshots
https://www.loom.com/share/99ec280393894b5196eb669b4f44dd4e