### PR TITLE
Search bar value for desktop not updated on search bar for mobile

### DIFF
--- a/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
+++ b/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
@@ -103,8 +103,7 @@ function PageWrapper(props) {
   });
 
   const [options, setOptions] = useState([]);
-  const [query, setQuery] = useState('');
-  const [queryInput, setQueryInput] = useState('');
+  const [query, setQuery] = useState(props.location.search ? getQueryParams(window.location.href).get('q') : '');
 
   const throttledFetchOptions = useMemo(
     () =>
@@ -210,6 +209,10 @@ function PageWrapper(props) {
     window.location.reload();
   };
 
+  const handleTextField = (event) => {
+    setQuery(event.target.value)
+  }
+
   const { anchor_el, loading, open_search_form } = state;
   const { t } = props;
   const { zubhub, hero } = props.projects;
@@ -305,11 +308,8 @@ function PageWrapper(props) {
                     <Autocomplete
                       className={classes.input}
                       options={options}
-                      defaultValue={{
-                        title:
-                          props.location.search &&
-                          getQueryParams(window.location.href).get('q'),
-                      }}
+                      defaultValue={{ title: query }}
+                      value={{ title: query }}
                       renderOption={(option, { inputValue }) => (
                         <Option
                           option={option}
@@ -317,7 +317,7 @@ function PageWrapper(props) {
                           onOptionClick={onSearchOptionClick}
                         />
                       )}
-                      onChange={onSearchOptionClick}
+
                     >
                       {params => (
                         <TextField
@@ -346,13 +346,8 @@ function PageWrapper(props) {
                               </InputAdornment>
                             ),
                             pattern: '(.|s)*S(.|s)*',
-                            defaultValue: {
-                              title:
-                                props.location.search &&
-                                getQueryParams(window.location.href).get('q'),
-                            },
                           }}
-                          onChange={e => setQuery(e.target.value)}
+                          onChange={handleTextField}
                           placeholder={`${t(
                             'pageWrapper.inputs.search.label',
                           )}...`}
@@ -755,10 +750,8 @@ function PageWrapper(props) {
                   <Autocomplete
                     style={{ width: '100%' }}
                     options={options}
-                    defaultValue={
-                      props.location.search &&
-                      getQueryParams(window.location.href).get('q')
-                    }
+                    defaultValue={{ title: query }}
+                    value={{ title: query }}
                     renderOption={(option, { inputValue }) => (
                       <Option
                         option={option}
@@ -766,7 +759,6 @@ function PageWrapper(props) {
                         onOptionClick={onSearchOptionClick}
                       />
                     )}
-                    onChange={onSearchOptionClick}
                   >
                     {params => (
                       <TextField
@@ -799,7 +791,7 @@ function PageWrapper(props) {
                         placeholder={`${t(
                           'pageWrapper.inputs.search.label',
                         )}...`}
-                        onChange={e => setQuery(e.target.value)}
+                        onChange={handleTextField}
                       />
                     )}
                   </Autocomplete>


### PR DESCRIPTION
## Summary

Description of PR.
This PR fixes the problem we had with the search input not persisting same value on mobile and on Desktop after resizing.
Closes #636 

## Changes

- Passed query data to Autocomplete component to control and persist the same value on both mobile and desktop input views

## Screenshots
https://www.loom.com/share/6f3a768942494a3fba4589ef927ea647