### PR TITLE
Password reset bug fix

### DIFF
--- a/zubhub_backend/zubhub/zubhub/settings.py
+++ b/zubhub_backend/zubhub/zubhub/settings.py
@@ -142,7 +142,10 @@ REST_FRAMEWORK = {
 REST_AUTH_REGISTER_SERIALIZERS = {
     'REGISTER_SERIALIZER': 'creators.serializers.CustomRegisterSerializer',
 }
-
+REST_AUTH_SERIALIZERS = {
+    'PASSWORD_RESET_SERIALIZER': 
+        'zubhub.serializers.CustomPasswordResetSerializer',
+}
 ACCOUNT_ADAPTER = 'creators.adapter.CustomAccountAdapter'
 
 AUTH_USER_MODEL = 'creators.Creator'

--- a/zubhub_backend/zubhub/zubhub/urls.py
+++ b/zubhub_backend/zubhub/zubhub/urls.py
@@ -52,7 +52,7 @@ if settings.DEFAULT_BACKEND_DOMAIN.startswith("localhost"):
             path('api/rest-auth/login/', LoginView.as_view()),
             path('api/rest-auth/logout/', LogoutView.as_view()),
             path('api/rest-auth/registration/verify-email/', VerifyEmailView.as_view()),
-            path('api/rest-auth/password/reset/', PasswordResetView.as_view()),
+            path('api/rest-auth/password/reset/', PasswordResetView.as_view()), 
             path('api/rest-auth/password/reset/confirm/', PasswordResetConfirmView.as_view()),
             path('api/creators/', include('creators.urls')),
             path('api/projects/', include('projects.urls')),

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/page_wrapper/pageWrapperStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/page_wrapper/pageWrapperStyles.js
@@ -263,9 +263,8 @@ const styles = theme => ({
     '&:hover': {
       color: 'rgb(254 211 42)',
     },
-  },
-
-  center: {
+  }, 
+   center: {
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/page_wrapper/pageWrapperStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/page_wrapper/pageWrapperStyles.js
@@ -259,7 +259,12 @@ const styles = theme => ({
   },
   footerLinkStyle: {
     color: 'white',
+    cursor: 'pointer',
+    '&:hover': {
+      color: 'rgb(254 211 42)',
+    },
   },
+
   center: {
     display: 'flex',
     justifyContent: 'center',


### PR DESCRIPTION
## Summary

When an email doesn't exist on the platform, the API should indicate it and we can let the user know that the email they used doesn't exist on the platform. This will also help us not to send unnecessary emails to people that don't have accounts.
Closes #654 

## Changes
- Added Custom Password Reset Serializer to zubhub.serializers
- Added Configuration for the serializer in settings.py

## Screenshots
![image](https://user-images.githubusercontent.com/29153968/225068104-42dec0ab-3d5f-480e-8a7d-2b92e3959969.png)


