### PR TITLE
Added 'Save as Draft' option and removal of 'All registered zubhub users' option

### DIFF
--- a/zubhub_frontend/zubhub/public/locales/en/translation.json
+++ b/zubhub_frontend/zubhub/public/locales/en/translation.json
@@ -367,8 +367,8 @@
         "topHelperText": "If you are still working on the project and are unsure if you want to publish this right away, select 'Only me'",
         "publishTypes": {
           "authenticatedCreators": "Only me",
-          "draft": "Only a few ZubHub users",
-          "preview": "All registered ZubHub users",
+          "draft": "Save as Draft",
+          "preview": "Only a few ZubHub users",
           "public": "Everyone on the internet"
         },
         "visibleTo": "Visible To",
@@ -802,19 +802,19 @@
         }
       },
       "materials_used": {
-      "label": "What materials did you use?",
-      "addMore": "Add Material",
-      "helperText": "List some of the essential materials used to create this activity",
-      "encouragingText": "We strongly encourage you to upload an image containing all materials and tools used to create this activity",
-      "images": {
-        "label": "Add Image"
-      },
-      "errors": {
-        "max": "your material shouldn't be more than 50 characters",
-        "required": "this field is required",
-        "required1": "At least one material is required!",
-        "min": "your material should be at least 2 characters"
-      }
+        "label": "What materials did you use?",
+        "addMore": "Add Material",
+        "helperText": "List some of the essential materials used to create this activity",
+        "encouragingText": "We strongly encourage you to upload an image containing all materials and tools used to create this activity",
+        "images": {
+          "label": "Add Image"
+        },
+        "errors": {
+          "max": "your material shouldn't be more than 50 characters",
+          "required": "this field is required",
+          "required1": "At least one material is required!",
+          "min": "your material should be at least 2 characters"
+        }
       },
       "facilitation_tips": {
         "label": "Facilitation tips",
@@ -824,7 +824,6 @@
           "max": "your facilitation tips shouldn't be more than 10,000 characters",
           "required": "This field is required"
         }
-
       },
       "activityImages": {
         "label": "Add Images of your activity",
@@ -869,28 +868,27 @@
         "image": {
           "label": "Add Example Image"
         },
-         "errors": {
+        "errors": {
           "max": "your inspiring example's description shouldn't be more than 100 characters",
           "required": "This field is required",
           "maxCredit": "your inspiring example's credit shouldn't be more than 50 characters"
-
         }
       },
-        "video": {
-          "label": "Let's add a video",
-          "label2": "Add Video",
-          "helperText": "You can provide video URL (Youtube, vimeo and Google Drive are supported) or a video file",
-          "errors": {
-            "shouldBeURL": "Select a valid video URL from YouTube, Vimeo, or Google Drive",
-            "shouldBeVideoFile": "Select a valid video file",
-            "maxVideoFileSize": "video file is more than 60MB",
-            "maxVideoURLLength": "video URL is too long"
-          }
+      "video": {
+        "label": "Let's add a video",
+        "label2": "Add Video",
+        "helperText": "You can provide video URL (Youtube, vimeo and Google Drive are supported) or a video file",
+        "errors": {
+          "shouldBeURL": "Select a valid video URL from YouTube, Vimeo, or Google Drive",
+          "shouldBeVideoFile": "Select a valid video file",
+          "maxVideoFileSize": "video file is more than 60MB",
+          "maxVideoURLLength": "video URL is too long"
+        }
       },
       "image": "Image added",
       "images": "Images added",
       "videoFile": "Video file added",
-      "videoURL": "Video URL added"  
+      "videoURL": "Video URL added"
     },
     "buttons": {
       "Next": "Next",
@@ -899,28 +897,28 @@
       "Edit": "Save Changes"
     }
   },
- "activities": {
-   "LinkedProjects": "Linked Projects",
-   "errors": {
+  "activities": {
+    "LinkedProjects": "Linked Projects",
+    "errors": {
       "emptyList": "No activities created yet !",
       "LinkedProjects": "No projects Linked to this activity yet created !",
       "dialog": {
-         "serverError": "Sorry the server is down try again later",
-         "mediaServerError": "Sorry media server is down we couldn't upload your files! try again later",
-         "uploadError": "error occurred while downloading file : "
+        "serverError": "Sorry the server is down try again later",
+        "mediaServerError": "Sorry media server is down we couldn't upload your files! try again later",
+        "uploadError": "error occurred while downloading file : "
       }
-   }
- },
+    }
+  },
 
   "activityDetails": {
     "subTitles": {
-       "learning_goals": "LEARNING GOALS",
-       "materials_required": "MATERIALS REQUIRED",
-       "making_steps": "MAKING STEPS",
-       "inspiring_person": "INSPIRING ARTIST/SCIENTIST",
-       "facilitation_tips": "FACILITATION TIPS",
-       "inspiring_examples": "SOME INSPIRING EXAMPLES",
-       "contributors": "CONTRIBUTORS"
+      "learning_goals": "LEARNING GOALS",
+      "materials_required": "MATERIALS REQUIRED",
+      "making_steps": "MAKING STEPS",
+      "inspiring_person": "INSPIRING ARTIST/SCIENTIST",
+      "facilitation_tips": "FACILITATION TIPS",
+      "inspiring_examples": "SOME INSPIRING EXAMPLES",
+      "contributors": "CONTRIBUTORS"
     },
     "made": "Made by",
     "activity": {
@@ -933,7 +931,7 @@
       "category": "Category",
       "tags": "Tags",
       "none": "None",
-      
+
       "build": "Let's Make This Project",
       "pdf": "Download Pdf",
       "create": {
@@ -967,20 +965,20 @@
         }
       },
       "publish": {
-         "label": "Publish"
+        "label": "Publish"
       },
       "unpublish": {
-         "label": "UnPublish"
+        "label": "UnPublish"
       }
     },
-      "saveButton": {
-        "label": "save button",
-        "save": "save",
-        "unsave": "unsave"
-      }
+    "saveButton": {
+      "label": "save button",
+      "save": "save",
+      "unsave": "unsave"
+    }
   },
-  "breadCrumb":{
-    "link":{
+  "breadCrumb": {
+    "link": {
       "activities": "Activities",
       "projects": "Projects",
       "edit": "Edit",
@@ -999,5 +997,4 @@
       "drafts": "drafts"
     }
   }
- 
 }

--- a/zubhub_frontend/zubhub/src/assets/css/index.css
+++ b/zubhub_frontend/zubhub/src/assets/css/index.css
@@ -599,6 +599,13 @@ html,
 .MuiInputBase-root #phone {
   width: 80%;
 }
-.MuiGrid-root #Numcenter {
-  line-height: 19px !important;
+.MuiGrid-root #sixCenter {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.MuiGrid-root #eightCenter{
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/zubhub_frontend/zubhub/src/assets/css/index.css
+++ b/zubhub_frontend/zubhub/src/assets/css/index.css
@@ -596,6 +596,9 @@ html,
   display: none !important;
 }
 
-.MuiInputBase-root #phone{
+.MuiInputBase-root #phone {
   width: 80%;
+}
+.MuiGrid-root #Numcenter {
+  line-height: 19px !important;
 }

--- a/zubhub_frontend/zubhub/src/assets/css/index.css
+++ b/zubhub_frontend/zubhub/src/assets/css/index.css
@@ -596,6 +596,6 @@ html,
   display: none !important;
 }
 
-.MuiInputBase-root #phone {
+.MuiInputBase-root #phone{
   width: 80%;
 }

--- a/zubhub_frontend/zubhub/src/assets/css/index.css
+++ b/zubhub_frontend/zubhub/src/assets/css/index.css
@@ -599,13 +599,3 @@ html,
 .MuiInputBase-root #phone {
   width: 80%;
 }
-.MuiGrid-root #sixCenter {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.MuiGrid-root #eightCenter{
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}

--- a/zubhub_frontend/zubhub/src/assets/js/muiTheme.js
+++ b/zubhub_frontend/zubhub/src/assets/js/muiTheme.js
@@ -4,4 +4,7 @@ export const theme = createMuiTheme({
   typography: {
     fontFamily: ['Raleway', 'Roboto', 'sans-serif'].join(','),
   },
+  circleBox: {
+    backgroundColor: '#00B8C4',
+  },
 });

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/create_project/createProjectStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/create_project/createProjectStyles.js
@@ -70,8 +70,8 @@ const styles = theme => ({
   circleBox: {
     height: '20px',
     width: '20px',
-    backgroundColor: '#00B8C4',
     color: 'white',
+    backgroundColor: [theme.circleBox.backgroundColor],
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
@@ -98,7 +98,7 @@ const styles = theme => ({
       borderBottomRightRadius: 15,
       borderBottomLeftRadius: 15,
       '& .ql-editor': {
-        WebkitUserSelect:'text',
+        WebkitUserSelect: 'text',
         color: '#000000de',
         fontSize: '1rem',
         fontFamily: 'Raleway,Roboto,sans-serif',
@@ -299,11 +299,11 @@ const styles = theme => ({
   },
   requiredLabelStyle: {
     display: 'inline-block',
-    color: 'red'
+    color: 'red',
   },
   errorMessage: {
-    color: 'red'
-  }
+    color: 'red',
+  },
 });
 
 export default styles;

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/create_project/createProjectStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/create_project/createProjectStyles.js
@@ -98,7 +98,7 @@ const styles = theme => ({
       borderBottomRightRadius: 15,
       borderBottomLeftRadius: 15,
       '& .ql-editor': {
-        WebkitUserSelect: 'text',
+        WebkitUserSelect:'text',
         color: '#000000de',
         fontSize: '1rem',
         fontFamily: 'Raleway,Roboto,sans-serif',
@@ -299,11 +299,11 @@ const styles = theme => ({
   },
   requiredLabelStyle: {
     display: 'inline-block',
-    color: 'red',
+    color: 'red'
   },
   errorMessage: {
-    color: 'red',
-  },
+    color: 'red'
+  }
 });
 
 export default styles;

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/create_project/createProjectStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/create_project/createProjectStyles.js
@@ -40,6 +40,7 @@ const styles = theme => ({
     },
     fontWeight: 'bold',
     fontSize: '1rem',
+    display:'flex',
     [theme.breakpoints.up('1600')]: {
       fontSize: '1.7rem',
     },
@@ -65,6 +66,23 @@ const styles = theme => ({
         fontSize: '1.7rem',
       },
     },
+  },
+  customBoxStyle:{
+     height: '20px',
+    width: '20px',
+    backgroundColor: '#00B8C4',
+    color: 'white',
+    display: 'flex',
+    alignItems:'center',
+    justifyContent:'center',
+    textAlign: 'center',
+    borderRadius: '50%',
+    lineHeight: '17px',
+    marginRight: '0.3em',
+    [theme.breakpoints.up('1600')]: {
+      fontSize: '1.2rem',
+    },
+    
   },
   descInputStyle: {
     color: 'black',
@@ -175,7 +193,6 @@ const styles = theme => ({
     width: '20px',
     backgroundColor: '#00B8C4',
     color: 'white',
-    display: 'inline-block',
     textAlign: 'center',
     borderRadius: '50%',
     lineHeight: '17px',

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/create_project/createProjectStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/create_project/createProjectStyles.js
@@ -40,7 +40,7 @@ const styles = theme => ({
     },
     fontWeight: 'bold',
     fontSize: '1rem',
-    display:'flex',
+    display: 'flex',
     [theme.breakpoints.up('1600')]: {
       fontSize: '1.7rem',
     },
@@ -67,14 +67,14 @@ const styles = theme => ({
       },
     },
   },
-  customBoxStyle:{
-     height: '20px',
+  circleBox: {
+    height: '20px',
     width: '20px',
     backgroundColor: '#00B8C4',
     color: 'white',
     display: 'flex',
-    alignItems:'center',
-    justifyContent:'center',
+    alignItems: 'center',
+    justifyContent: 'center',
     textAlign: 'center',
     borderRadius: '50%',
     lineHeight: '17px',
@@ -82,7 +82,6 @@ const styles = theme => ({
     [theme.breakpoints.up('1600')]: {
       fontSize: '1.2rem',
     },
-    
   },
   descInputStyle: {
     color: 'black',
@@ -99,7 +98,7 @@ const styles = theme => ({
       borderBottomRightRadius: 15,
       borderBottomLeftRadius: 15,
       '& .ql-editor': {
-        WebkitUserSelect:'text',
+        WebkitUserSelect: 'text',
         color: '#000000de',
         fontSize: '1rem',
         fontFamily: 'Raleway,Roboto,sans-serif',
@@ -300,11 +299,11 @@ const styles = theme => ({
   },
   requiredLabelStyle: {
     display: 'inline-block',
-    color: 'red'
+    color: 'red',
   },
   errorMessage: {
-    color: 'red'
-  }
+    color: 'red',
+  },
 });
 
 export default styles;

--- a/zubhub_frontend/zubhub/src/views/create_project/CreateProject.jsx
+++ b/zubhub_frontend/zubhub/src/views/create_project/CreateProject.jsx
@@ -642,12 +642,16 @@ function CreateProject(props) {
                             color="textSecondary"
                             className={classes.customLabelStyle}
                           >
+<<<<<<< Updated upstream
                             <Box
                               className={classes.fieldNumberStyle}
                               id="sixCenter"
                             >
                               6
                             </Box>
+=======
+                            <Box className={classes.customBoxStyle}>6</Box>
+>>>>>>> Stashed changes
                             {t('createProject.inputs.category.label')}
                           </Typography>
                         </label>
@@ -848,12 +852,16 @@ function CreateProject(props) {
                             color="textSecondary"
                             className={classes.customLabelStyle}
                           >
+<<<<<<< Updated upstream
                             <Box
                               className={classes.fieldNumberStyle}
                               id="eightCenter"
                             >
                               8
                             </Box>
+=======
+                            <Box className={classes.customBoxStyle}>8</Box>
+>>>>>>> Stashed changes
                             {t('createProject.inputs.publish.label')}
                           </Typography>
                         </label>

--- a/zubhub_frontend/zubhub/src/views/create_project/CreateProject.jsx
+++ b/zubhub_frontend/zubhub/src/views/create_project/CreateProject.jsx
@@ -644,7 +644,7 @@ function CreateProject(props) {
                           >
                             <Box
                               className={classes.fieldNumberStyle}
-                              id="Numcenter"
+                              id="sixCenter"
                             >
                               6
                             </Box>
@@ -850,7 +850,7 @@ function CreateProject(props) {
                           >
                             <Box
                               className={classes.fieldNumberStyle}
-                              id="Numcenter"
+                              id="eightCenter"
                             >
                               8
                             </Box>

--- a/zubhub_frontend/zubhub/src/views/create_project/CreateProject.jsx
+++ b/zubhub_frontend/zubhub/src/views/create_project/CreateProject.jsx
@@ -642,16 +642,7 @@ function CreateProject(props) {
                             color="textSecondary"
                             className={classes.customLabelStyle}
                           >
-<<<<<<< Updated upstream
-                            <Box
-                              className={classes.fieldNumberStyle}
-                              id="sixCenter"
-                            >
-                              6
-                            </Box>
-=======
-                            <Box className={classes.customBoxStyle}>6</Box>
->>>>>>> Stashed changes
+                            <Box className={classes.circleBox}>6</Box>
                             {t('createProject.inputs.category.label')}
                           </Typography>
                         </label>
@@ -852,16 +843,7 @@ function CreateProject(props) {
                             color="textSecondary"
                             className={classes.customLabelStyle}
                           >
-<<<<<<< Updated upstream
-                            <Box
-                              className={classes.fieldNumberStyle}
-                              id="eightCenter"
-                            >
-                              8
-                            </Box>
-=======
-                            <Box className={classes.customBoxStyle}>8</Box>
->>>>>>> Stashed changes
+                            <Box className={classes.circleBox}>8</Box>
                             {t('createProject.inputs.publish.label')}
                           </Typography>
                         </label>

--- a/zubhub_frontend/zubhub/src/views/create_project/CreateProject.jsx
+++ b/zubhub_frontend/zubhub/src/views/create_project/CreateProject.jsx
@@ -642,7 +642,12 @@ function CreateProject(props) {
                             color="textSecondary"
                             className={classes.customLabelStyle}
                           >
-                            <Box className={classes.fieldNumberStyle}>6</Box>
+                            <Box
+                              className={classes.fieldNumberStyle}
+                              id="Numcenter"
+                            >
+                              6
+                            </Box>
                             {t('createProject.inputs.category.label')}
                           </Typography>
                         </label>
@@ -843,7 +848,12 @@ function CreateProject(props) {
                             color="textSecondary"
                             className={classes.customLabelStyle}
                           >
-                            <Box className={classes.fieldNumberStyle}>8</Box>
+                            <Box
+                              className={classes.fieldNumberStyle}
+                              id="Numcenter"
+                            >
+                              8
+                            </Box>
                             {t('createProject.inputs.publish.label')}
                           </Typography>
                         </label>


### PR DESCRIPTION
## Summary
This PR renames the options as per operations 
The option `Only few zubhub users` is renamed to `Save as Draft` and `All registered zubhub users` is renamed to  `Only few zubhub users` this changes are done because  when we select option `All registered ZubHub` users it is showing for adding usernames but it is not possible to determine all the ZubHub users by taking as input and while we select option `Only few zubhub users` it saves the project to drafts so it would be perfect for renaming the options so the issue will be solved 

Closes #592, Closes #593
## Changes
- Renaming of options in translation.json file
## Screenshots
<img width="520" alt="Screenshot 2023-03-16 at 3 16 17 PM" src="https://user-images.githubusercontent.com/88829894/225581329-82b60333-aad3-4aba-8a5b-63b5a173353a.png">

