### PR TITLE
Colour updation of buttons for hover effect

### DIFF
--- a/zubhub_frontend/zubhub/src/assets/js/styles/components/button/buttonStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/components/button/buttonStyles.js
@@ -39,23 +39,23 @@ const styles = theme => ({
       color: 'white',
       backgroundColor: '#9A0036',
     },
-  }, 
+  },
   darkDangerButtonStyle: {
     borderRadius: 30,
     backgroundColor: '#9A0036',
     color: 'white',
     '&:hover': {
       color: 'white',
-      backgroundColor: '#9A0036',
+      backgroundColor: '#5E0423',
     },
   },
   customWarningButtonStyle: {
     borderRadius: 30,
     backgroundColor: '#FECB00',
-    color: '#896e00',
+    color: 'white', // previous colour #896e00
     '&:hover': {
-      color: '#896e00',
-      backgroundColor: '#FECB00',
+      color: 'white',
+      backgroundColor: '#C49d00',
     },
   },
   mediaUploadButtonStyle: {

--- a/zubhub_frontend/zubhub/src/assets/js/styles/components/button/buttonStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/components/button/buttonStyles.js
@@ -52,7 +52,7 @@ const styles = theme => ({
   customWarningButtonStyle: {
     borderRadius: 30,
     backgroundColor: '#FECB00',
-    color: 'white', // previous colour #896e00
+    color: 'white',
     '&:hover': {
       color: 'white',
       backgroundColor: '#C49d00',


### PR DESCRIPTION
## Summary

This change in hex colour makes the `darkDangerButtonStyle` for explore idea page and `customWarningButtonStyle` for Be an ambassador button hoverable.
 
Fixes #629

