### PR TITLE
#627 Rectified the merging of Email label inside input border when opened for the first time

### DIFF
--- a/zubhub_frontend/zubhub/src/views/login/Login.jsx
+++ b/zubhub_frontend/zubhub/src/views/login/Login.jsx
@@ -136,10 +136,7 @@ function Login(props) {
                         type="text"
                         onChange={props.handleChange}
                         onBlur={props.handleBlur}
-                        labelWidth={calculateLabelWidth(
-                          t('login.inputs.username.label'),
-                          document,
-                        )}
+                        label="Username Or Email"
                       />
                       <FormHelperText
                         className={classes.fieldHelperTextStyle}
@@ -198,10 +195,7 @@ function Login(props) {
                             </IconButton>
                           </InputAdornment>
                         }
-                        labelWidth={calculateLabelWidth(
-                          t('login.inputs.password.label'),
-                          document,
-                        )}
+                        label="password"
                       />
                       <FormHelperText
                         className={classes.fieldHelperTextStyle}

--- a/zubhub_frontend/zubhub/src/views/password_reset/PasswordReset.jsx
+++ b/zubhub_frontend/zubhub/src/views/password_reset/PasswordReset.jsx
@@ -114,10 +114,7 @@ function PasswordReset(props) {
                         type="text"
                         onChange={props.handleChange}
                         onBlur={props.handleBlur}
-                        labelWidth={calculateLabelWidth(
-                          t('passwordReset.inputs.email.label'),
-                          document,
-                        )}
+                        label="email"
                       />
                       <FormHelperText
                         className={classes.fieldHelperTextStyle}


### PR DESCRIPTION
## Summary
Email label is getting merged inside input border when open for the first time this issue can be solved by this PR

Closes #627 

## Changes

- Removed `labelWidth` property which is causing the bug
- Added `label` to the `outlined` component which allocates width statically

## Screenshots

![Screenshot from 2023-03-20 01-48-19](https://user-images.githubusercontent.com/88829894/226206704-6f4901e6-f3ee-4030-90f3-7416f55b62ab.png)

![Screenshot from 2023-03-20 01-48-41](https://user-images.githubusercontent.com/88829894/226206736-bc514d20-ca1b-48d8-acfa-2843ab946df4.png)

