### PR TITLE
Added 'Save as Draft' option and removal of 'All registered zubhub users' option

### DIFF
--- a/zubhub_frontend/zubhub/public/locales/en/translation.json
+++ b/zubhub_frontend/zubhub/public/locales/en/translation.json
@@ -368,8 +368,8 @@
         "topHelperText": "If you are still working on the project and are unsure if you want to publish this right away, select 'Only me'",
         "publishTypes": {
           "authenticatedCreators": "Only me",
-          "draft": "Only a few ZubHub users",
-          "preview": "All registered ZubHub users",
+          "draft": "Save as Draft",
+          "preview": "Only a few ZubHub users",
           "public": "Everyone on the internet"
         },
         "visibleTo": "Visible To",


### PR DESCRIPTION
## Summary
This PR renames the options as per operations
The option Only few zubhub users is renamed to Save as Draft and All registered zubhub users is renamed to Only few zubhub users this changes are done because when we select option All registered ZubHub users it is showing for adding usernames but it is not possible to determine all the ZubHub users by taking as input and while we select option Only few zubhub users it saves the project to drafts so it would be perfect for renaming the options so the issue will be solved

## Changes
- Renaming of options in translation.json file


## Screenshots
<img width="520" alt="Screenshot 2023-03-16 at 3 16 17 PM" src="https://user-images.githubusercontent.com/88829894/225581329-82b60333-aad3-4aba-8a5b-63b5a173353a.png">
