### PR TITLE
tests: add tests for projects

### DIFF
--- a/zubhub_backend/zubhub/creators/tests/test_views.py
+++ b/zubhub_backend/zubhub/creators/tests/test_views.py
@@ -44,7 +44,7 @@ class FetchAuthUserApiTests(TestCase):
     def test_user_for_profile_retrieval(self):
         """Test that you can retrieve user profile with given username"""
         res = self.client.post(reverse("creators:signup_creator"), self.payload)
-        url = self.client.get(("/api/creators/test_dummy/"))
+        url = self.client.get(reverse("creators:user_profile", args=["test_dummy"]))
         self.assertEqual(url.status_code, status.HTTP_200_OK)
 
     def test_fetch_authenticated_user(self):

--- a/zubhub_backend/zubhub/projects/tests/test_models.py
+++ b/zubhub_backend/zubhub/projects/tests/test_models.py
@@ -1,0 +1,54 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from projects.models import PublishingRule, Category, Project
+from zubhub.creators.models import Creator
+
+
+class PublishingRuleTest(TestCase):
+    def test_model_fields(self):
+        rule = PublishingRule(type=PublishingRule.DRAFT, publisher_id="test-publisher-id")
+        rule.save()
+        self.assertEqual(rule.type, PublishingRule.DRAFT)
+        self.assertEqual(rule.publisher_id, "test-publisher-id")
+
+    def test_model_str_representation(self):
+        rule = PublishingRule(type=PublishingRule.DRAFT, publisher_id="test-publisher-id")
+        rule.save()
+        self.assertEqual(str(rule), "DRAFT")
+
+class CategoryTest(TestCase):
+    def test_model_fields(self):
+        category = Category(name="test-category", description="test-description")
+        category.save()
+        self.assertEqual(category.name, "test-category")
+        self.assertEqual(category.description, "test-description")
+
+    def test_model_str_representation(self):
+        category = Category(name="test-category", description="test-description")
+        category.save()
+        self.assertEqual(str(category), "test-category")
+
+class ProjectTest(TestCase):
+    def setUp(self):
+        self.creator = Creator.objects.create(username="krishna")
+        self.category = Category.objects.create(name="test-category")
+        self.rule = PublishingRule.objects.create(type=PublishingRule.PUBLIC)
+        self.project = Project.objects.create(
+            creator=self.creator,
+            title="test-project",
+            description="test-description",
+            materials_used="test-materials-used",
+            category=self.category,
+            publish=self.rule
+        )
+
+    def test_model_fields(self):
+        self.assertEqual(self.project.creator, self.creator)
+        self.assertEqual(self.project.title, "test-project")
+        self.assertEqual(self.project.description, "test-description")
+        self.assertEqual(self.project.materials_used, "test-materials-used")
+        self.assertEqual(self.project.category, self.category)
+        self.assertEqual(self.project.publish, self.rule)
+
+    def test_model_str_representation(self):
+        self.assertEqual(str(self.project), "test-project")

--- a/zubhub_backend/zubhub/projects/tests/test_views.py
+++ b/zubhub_backend/zubhub/projects/tests/test_views.py
@@ -1,0 +1,94 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase, APIClient
+from projects.models import Project, Tag, Comment, Category
+from creators.models import Creator
+from django.utils import timezone
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+class ProjectViewsTestCase(APITestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user  = Creator.objects.create(username="John", password="password")
+        self.client.force_authenticate(user=self.user)
+        self.category = Category.objects.create(
+            name='Test Category'
+        )
+        self.tag = Tag.objects.create(
+            name='Test Tag'
+        )
+        self.project = Project.objects.create(
+            title='Test Project',
+            description='This is a test project',
+            creator=self.user,
+            category=self.category
+        )
+        self.project.tags.add(self.tag)
+        self.comment = Comment.objects.create(
+            project=self.project,
+            author=self.user,
+            content='Test comment',
+            created_at=timezone.now()
+        )
+        self.project_image = SimpleUploadedFile(
+            name='test_project_image.jpg',
+            content=open('test_project_image.jpg', 'rb').read(),
+            content_type='image/jpeg'
+        )
+
+    def test_list_projects(self):
+        url = reverse('projects:list_projects')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['title'], 'Test Project')
+        self.assertEqual(response.data[0]['description'], 'This is a test project')
+        self.assertEqual(response.data[0]['creator']['username'], 'testuser')
+        self.assertEqual(response.data[0]['category']['name'], 'Test Category')
+        self.assertEqual(response.data[0]['tags'][0]['name'], 'Test Tag')
+        self.assertEqual(response.data[0]['comments_count'], 1)
+        self.assertEqual(response.data[0]['likes_count'], 0)
+        self.assertEqual(response.data[0]['saved_count'], 0)
+
+    def test_autocomplete_tags(self):
+        url = reverse('projects:autocomplete_tags')
+        response = self.client.get(url, {'q': 'Test'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], 'Test Tag')
+
+    def test_search_tags(self):
+        url = reverse('projects:search_tags')
+        response = self.client.get(url, {'q': 'Test'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], 'Test Tag')
+
+    def test_autocomplete_projects(self):
+        url = reverse('projects:autocomplete_projects')
+        response = self.client.get(url, {'q': 'Test'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['title'], 'Test Project')
+
+    def test_search_projects(self):
+        url = reverse('projects:search_projects')
+        response = self.client.get(url, {'q': 'Test'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['title'], 'Test Project')
+
+    def test_create_project(self):
+        url = reverse('projects:create_project')
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.key)
+        data = {
+            'title': 'New Test Project',
+            'description': 'This is a new test project',
+            'category': self.category.id,
+            'tags': [self.tag1.id, self.tag2.id],
+            'is_published': True
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Project.objects.count(), 3)
+


### PR DESCRIPTION
## Summary

This PR adds tests for the projects app to ensure models and views are working as expected.

## Changes

-   Added test cases for the `PublishingRule` model 
-   Added test cases for the `Category` model 
-   Added test cases for the `Project` model 
-   Added test cases for views in `test_views`

This PR partially closes #689 