### PR TITLE
changed the visibility (globe) icon

### DIFF
--- a/zubhub_frontend/zubhub/src/components/project/Project.jsx
+++ b/zubhub_frontend/zubhub/src/components/project/Project.jsx
@@ -7,8 +7,8 @@ import { makeStyles } from '@material-ui/core/styles';
 import BookmarkIcon from '@material-ui/icons/Bookmark';
 import BookmarkBorderIcon from '@material-ui/icons/BookmarkBorder';
 import VisibilityIcon from '@material-ui/icons/Visibility';
-import LockIcon from '@material-ui/icons/Lock';
-import PublicIcon from '@material-ui/icons/Public';
+import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
+
 import {
   Tooltip,
   Avatar,
@@ -72,12 +72,14 @@ function Project(props) {
                 : ''}
               {project.publish.type ===
                 publish_type['Authenticated Creators'] ? (
-                <LockIcon />
+                  // t('project.publish.private')
+                  <VisibilityOffIcon />
               ) : (
                 ''
               )}
               {project.publish.type === publish_type.Public ? (
-                <PublicIcon />
+                // t('project.publish.public')
+                <VisibilityIcon />
               ) : (
                 ''
               )}


### PR DESCRIPTION
## Summary

Closes #556 

## Changes

- Changed the icon as per the new design

## Screenshots
<img width="488" alt="Screenshot 2023-05-24 at 03 08 11" src="https://github.com/unstructuredstudio/zubhub/assets/43777817/266a31c5-4525-4f4c-a9a9-7933714ecfe1">
<img width="394" alt="Screenshot 2023-05-24 at 03 08 45" src="https://github.com/unstructuredstudio/zubhub/assets/43777817/7bac5bc7-2a4b-4870-bb9c-40e928ad6fa2">
