### PR TITLE
Change rabbitmq image

### DIFF
--- a/zubhub_backend/docker-compose.prod.yml
+++ b/zubhub_backend/docker-compose.prod.yml
@@ -34,7 +34,7 @@ services:
       - web
 
   rabbitmq:
-    image: rabbitmq:3-management
+    image: bitnami/rabbitmq:3.11
     env_file: .env
     deploy:
       replicas: 1


### PR DESCRIPTION
Change the `rabbitmq` image and use a bitnami one  so we don't have to use privileged mode. Fixes issue in production where container aborts

