### PR TITLE
fix: Enable Draft projects not to show up in the search bar for user who created it #581

### DIFF
--- a/zubhub_frontend/zubhub/src/components/Navbar/Navbar.jsx
+++ b/zubhub_frontend/zubhub/src/components/Navbar/Navbar.jsx
@@ -112,7 +112,9 @@ function PageWrapper(props) {
           }));
         } else if (searchType === SearchType.PROJECTS) {
           completions = await api.autocompleteProjects({ query, token });
-          completions = completions.map(({ id, title, creator, images }) => ({
+          completions = completions
+          .filter(c=>( c.creator.id === props.auth.id && c.publish.type !== 1 ))
+          .map(({ id, title, creator, images }) => ({
             title,
             shortInfo: creator.username,
             image: images.length > 0 ? images[0].image_url : null,


### PR DESCRIPTION
## Summary

This PR is to enable Draft projects not to show up in the search bar for the user who created it. Just as in the screenshot below, when the user searches for projects, the draft project with the name `Eduvusion` doesn't show up in the search bar. It only shows the `Eduvision_Not_Draft` project which is not a draft
Closes #581

## Changes

- Filter out the projects that are drafts and that belong to the user in `Navbar.jsx` file
<img width="1068" alt="Screenshot 2023-10-04 at 05 52 00" src="https://github.com/unstructuredstudio/zubhub/assets/51094040/a61302ef-4ee2-4fa8-bfe9-2917b00769f9">

## Screenshots
<img width="1680" alt="Screenshot 2023-10-04 at 05 38 49" src="https://github.com/unstructuredstudio/zubhub/assets/51094040/91dc5896-c349-4049-a351-d9c531449889">