### PR TITLE
fix:add forgot password to `PageWrapper.jsx` so that it can be called when the user is not logged in

### DIFF
--- a/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
+++ b/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
@@ -236,6 +236,9 @@ function PageWrapper(props) {
             '/terms_of_use',
             '/about',
             '/challenge',
+            '/password-reset',
+            '/email-confirm',
+            '/password-reset-confirm'
           ].includes(props.match?.path) && (
             <div style={{ minHeight: '80vh' }}>
               <NotFoundPage />
@@ -247,6 +250,7 @@ function PageWrapper(props) {
           '/',
           '/signup',
           '/login',
+          '/password-reset',
           '/projects/:id',
           '/ambassadors',
           '/creators/:username',
@@ -254,6 +258,8 @@ function PageWrapper(props) {
           '/terms_of_use',
           '/about',
           '/challenge',
+          '/email-confirm',
+          '/password-reset-confirm'
         ].includes(props.match?.path) && <div style={{ minHeight: '90vh' }}>{props.children}</div>}
 
       <footer className={clsx('footer-distributed', classes.footerStyle)}>


### PR DESCRIPTION

## Summary

Fix the forgot flow by adding required routes to `PageWrapper.jsx`
Closes #741 

## Changes

- Include the following routes to the conditional statement for when the user is not logged in, and the route is not found
<img width="721" alt="Screenshot 2023-10-04 at 20 10 22" src="https://github.com/unstructuredstudio/zubhub/assets/51094040/b6520041-f724-4798-ba6e-094f982d9afe">

- Include the following routes to the conditional statement for when the user is not logged in, and the route is found
<img width="816" alt="Screenshot 2023-10-04 at 20 10 42" src="https://github.com/unstructuredstudio/zubhub/assets/51094040/21d27111-0e9b-4e61-9710-25400f3ef19f">


## Screenshots


<img width="1680" alt="Screenshot 2023-10-04 at 19 59 52" src="https://github.com/unstructuredstudio/zubhub/assets/51094040/864060c4-bb8c-4a84-b65c-6240635e94e7">


<img width="1680" alt="Screenshot 2023-10-04 at 20 00 07" src="https://github.com/unstructuredstudio/zubhub/assets/51094040/5a5535c8-c3c2-45f6-a45e-d522c4b18956">

