### PR TITLE
fix[functionality]: Enable the Comments count on the featured Projects to show up. Editted `Project.jsx` component

### DIFF
--- a/zubhub_frontend/zubhub/src/components/project/Project.jsx
+++ b/zubhub_frontend/zubhub/src/components/project/Project.jsx
@@ -168,7 +168,7 @@ function Project(props) {
                   variant="caption"
                   component="span"
                 >
-                  <CommentIcon /> {project.comments_count}
+                  <CommentIcon /> {project.comments ? project.comments.length : project.comments_count }
                 </Typography>
               </Box>
               <Typography color="textSecondary" variant="caption" component="span" className={classes.date}>


### PR DESCRIPTION
…

## Summary

Enable the Comments number on the featured Projects to show up. Edited `Project.jsx` component
Closes #670,

## Changes

- Put a conditional statement in the `Project.jsx` file online 171 to call the count depending on whether is it a `StaffPickedProject` or a  normal `Project`

## Demo

https://github.com/unstructuredstudio/zubhub/assets/51094040/115b3d04-f6b3-4031-aead-0c9757f6d648

So here, the comments show on both Project types, whether featured or not
