### PR TITLE
(feat) Implement a reusable route protection component

### DIFF
--- a/zubhub_frontend/zubhub/src/App.js
+++ b/zubhub_frontend/zubhub/src/App.js
@@ -1,97 +1,50 @@
-import React, { useContext }  from 'react';
+import React, { useContext } from 'react';
 import { withTranslation } from 'react-i18next';
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
-import CreateActivity from './views/create_activity/CreateActivity';
-import { useEffect, useState } from "react";
+import { BrowserRouter as Router, Route, Redirect, Switch } from 'react-router-dom';
+import CreateActivity from './views/create_activity/create_activity';
+import { useEffect } from 'react';
+import { connect } from 'react-redux';
 import LoadingPage from './views/loading/LoadingPage';
 import PageWrapper from './views/PageWrapper';
 import ZubhubAPI from '../src/api/api';
 import { updateTheme } from './theme';
 import ScrollToTop from './ScrollToTop';
 
-const SearchResults = React.lazy(() =>
-  import('./views/search_results/SearchResults'),
-);
+const SearchResults = React.lazy(() => import('./views/search_results/SearchResults'));
 
 const Signup = React.lazy(() => import('./views/signup/Signup'));
 const Login = React.lazy(() => import('./views/login/Login'));
-const PasswordReset = React.lazy(() =>
-  import('./views/password_reset/PasswordReset'),
-);
-const PasswordResetConfirm = React.lazy(() =>
-  import('./views/password_reset_confirm/PasswordResetConfirm'),
-);
-const EmailConfirm = React.lazy(() =>
-  import('./views/email_confirm/EmailConfirm'),
-);
-const PhoneConfirm = React.lazy(() =>
-  import('./views/phone_confirm/PhoneConfirm'),
-);
+const PasswordReset = React.lazy(() => import('./views/password_reset/PasswordReset'));
+const PasswordResetConfirm = React.lazy(() => import('./views/password_reset_confirm/PasswordResetConfirm'));
+const EmailConfirm = React.lazy(() => import('./views/email_confirm/EmailConfirm'));
+const PhoneConfirm = React.lazy(() => import('./views/phone_confirm/PhoneConfirm'));
 const Profile = React.lazy(() => import('./views/profile/Profile'));
 const Team = React.lazy(() => import('./views/team/Team'));
-const EditTeam = React.lazy(() =>
-  import('./views/edit_team/EditTeam'),
-);
-const AccounStatus = React.lazy(() =>
-  import('./views/account_status/AccountStatus'),
-);
-const EditProfile = React.lazy(() =>
-  import('./views/edit_profile/EditProfile'),
-);
-const UserProjects = React.lazy(() =>
-  import('./views/user_projects/UserProjects'),
-);
-const TeamProjects = React.lazy(() =>
-  import('./views/team_projects/TeamProjects'),
-);
+const EditTeam = React.lazy(() => import('./views/edit_team/EditTeam'));
+const AccounStatus = React.lazy(() => import('./views/account_status/AccountStatus'));
+const EditProfile = React.lazy(() => import('./views/edit_profile/EditProfile'));
+const UserProjects = React.lazy(() => import('./views/user_projects/UserProjects'));
+const TeamProjects = React.lazy(() => import('./views/team_projects/TeamProjects'));
 const UserDrafts = React.lazy(() => import('./views/user_drafts/UserDrafts'));
-const UserFollowers = React.lazy(() =>
-  import('./views/user_followers/UserFollowers'),
-);
-const TeamFollowers = React.lazy(() =>
-  import('./views/team_followers/TeamFollowers'),
-);
-const TeamMembers = React.lazy(() =>
-  import('./views/team_members/TeamMembers'),
-);
-const UserFollowing = React.lazy(() =>
-  import('./views/user_following/UserFollowing'),
-);
-const AllTeams = React.lazy(() =>
-  import('./views/all_teams/AllTeams'),
-);
-const Teams = React.lazy(() =>
-  import('./views/teams/Teams'),
-);
-const GroupMembers = React.lazy(() =>
-  import('./views/group_members/GroupMembers'),
-);
-const AddGroupMembers = React.lazy(() =>
-  import('./views/add_group_members/AddGroupMembers'),
-);
-const GroupInviteConfirm = React.lazy(() =>
-  import('./views/group_invite_confirm/GroupInviteConfirm'),
-);
+const UserFollowers = React.lazy(() => import('./views/user_followers/UserFollowers'));
+const TeamFollowers = React.lazy(() => import('./views/team_followers/TeamFollowers'));
+const TeamMembers = React.lazy(() => import('./views/team_members/TeamMembers'));
+const UserFollowing = React.lazy(() => import('./views/user_following/UserFollowing'));
+const AllTeams = React.lazy(() => import('./views/all_teams/AllTeams'));
+const Teams = React.lazy(() => import('./views/teams/Teams'));
+const GroupMembers = React.lazy(() => import('./views/group_members/GroupMembers'));
+const AddGroupMembers = React.lazy(() => import('./views/add_group_members/AddGroupMembers'));
+const GroupInviteConfirm = React.lazy(() => import('./views/group_invite_confirm/GroupInviteConfirm'));
 const Projects = React.lazy(() => import('./views/projects/Projects'));
 const Home = React.lazy(() => import('./views/home/Home'));
-const SavedProjects = React.lazy(() =>
-  import('./views/saved_projects/SavedProjects'),
-);
+const SavedProjects = React.lazy(() => import('./views/saved_projects/SavedProjects'));
 const CreateProject = React.lazy(() => import('./views/create_project/CreateProject'));
-const ProjectDetails = React.lazy(() =>
-  import('./views/project_details/ProjectDetails'),
-);
-const StaffPickDetails = React.lazy(() =>
-  import('./views/staff_pick_details/StaffPickDetails'),
-);
+const ProjectDetails = React.lazy(() => import('./views/project_details/ProjectDetails'));
+const StaffPickDetails = React.lazy(() => import('./views/staff_pick_details/StaffPickDetails'));
 const Activities = React.lazy(() => import('./views/activities/activities'));
-const ActivityDetails = React.lazy(() =>
-  import('./views/activity_details/ActivityDetailsV2'),
-);
+const ActivityDetails = React.lazy(() => import('./views/activity_details/ActivityDetailsV2'));
 const CreateTeam = React.lazy(() => import('./views/create_team/CreateTeam'));
-const LinkedProjects = React.lazy(() =>
-  import('./views/linked_projects/LinkedProjects'),
-);
+const LinkedProjects = React.lazy(() => import('./views/linked_projects/LinkedProjects'));
 const Ambassadors = React.lazy(() => import('./views/ambassadors/Ambassadors'));
 const Guidelines = React.lazy(() => import('./views/guidelines/Guidelines'));
 const TermsOfUse = React.lazy(() => import('./views/terms_of_use/TermsOfUse'));
@@ -102,7 +55,6 @@ const NotFound = React.lazy(() => import('./views/not_found/NotFound'));
 const API = new ZubhubAPI();
 const Settings = React.lazy(() => import('./views/settings/Settings'));
 
-
 const LazyImport = props => {
   const { LazyComponent, ...restOfProps } = props;
   return (
@@ -112,10 +64,26 @@ const LazyImport = props => {
   );
 };
 
+const ProtectedRoute = ({ component: LazyComponent, ...props }) => {
+  return (
+    <Route
+      {...props}
+      render={routeProps =>
+        props.auth?.token ? (
+          <PageWrapper {...props} {...routeProps}>
+            <LazyImport LazyComponent={LazyComponent} {...routeProps} {...props} />
+          </PageWrapper>
+        ) : (
+          <Redirect to="/login" />
+        )
+      }
+    />
+  );
+};
+
 const ThemeContext = React.createContext();
 
 function App(props) {
-
   const theme = useContext(ThemeContext);
 
   useEffect(() => {
@@ -134,39 +102,30 @@ function App(props) {
 
   return (
     <ThemeContext.Provider value={theme}>
-    <Router>
-      <ScrollToTop />
-      <Switch>
-        <Route
-          exact={true}
-          path="/"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport LazyComponent={Home} {...routeProps} {...props} />
-            </PageWrapper>
-          )}
-        />
+      <Router>
+        <ScrollToTop />
+        <Switch>
+          <Route
+            exact={true}
+            path="/"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={Home} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          exact={true}
-          path="/projects"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport LazyComponent={Projects} {...routeProps} {...props} />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            exact={true}
+            path="/projects"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={Projects} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          exact={true}
-          path="/projects"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport LazyComponent={Projects} {...routeProps} {...props} />
-            </PageWrapper>
-          )}
-        />
-        {/* <Route
+          {/* <Route
           exact={true}
           path="/projects/:id/preview"
           render={routeProps => (
@@ -175,555 +134,401 @@ function App(props) {
             </PageWrapper>
           )}
         /> */}
-        <Route
-          exact={true}
-          path="/settings"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport LazyComponent={Settings} {...routeProps} {...props} />
-            </PageWrapper>
-          )}
-        />
-        <Route
-          path="/activities/create"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={CreateActivity}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
 
-        <Route
-          path="/activities/:id/linkedProjects"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={LinkedProjects}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <ProtectedRoute path="/settings" component={Settings} {...props} />
 
-        <Route
-          path="/search"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={SearchResults}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/activities/create"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={CreateActivity} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/signup"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport LazyComponent={Signup} {...routeProps} {...props} />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/activities/:id/linkedProjects"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={LinkedProjects} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/login"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport LazyComponent={Login} {...routeProps} {...props} />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/search"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={SearchResults} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/password-reset"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={PasswordReset}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/signup"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={Signup} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/password-reset-confirm"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={PasswordResetConfirm}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/login"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={Login} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/email-confirm"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={EmailConfirm}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/password-reset"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={PasswordReset} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/phone-confirm"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={PhoneConfirm}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/password-reset-confirm"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={PasswordResetConfirm} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/group-invite-confirm"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={GroupInviteConfirm}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/email-confirm"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={EmailConfirm} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/creators/:username/projects"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={UserProjects}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/phone-confirm"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={PhoneConfirm} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/teams/:groupname/projects"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={TeamProjects}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/group-invite-confirm"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={GroupInviteConfirm} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/creators/:username/drafts"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={UserDrafts}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/creators/:username/projects"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={UserProjects} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/creators/:username/followers"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={UserFollowers}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/teams/:groupname/projects"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={TeamProjects} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-<Route
-          path="/teams/:groupname/followers"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={TeamFollowers}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/creators/:username/drafts"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={UserDrafts} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/teams/:groupname/members"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={TeamMembers}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/creators/:username/followers"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={UserFollowers} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/creators/:username/following"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={UserFollowing}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/teams/:groupname/followers"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={TeamFollowers} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/teams/all"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={AllTeams}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/teams/:groupname/members"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={TeamMembers} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/team"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={Teams}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/creators/:username/following"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={UserFollowing} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/creators/:username/members"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={GroupMembers}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/teams/all"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={AllTeams} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/creators/:username/add-members"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={AddGroupMembers}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <ProtectedRoute path="/team" component={Teams} {...props} />
 
-        <Route
-          path="/creators/:username"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport LazyComponent={Profile} {...routeProps} {...props} />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/creators/:username/members"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={GroupMembers} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/account-status"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={AccounStatus}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/creators/:username/add-members"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={AddGroupMembers} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/teams/:groupname"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport LazyComponent={Team} {...routeProps} {...props} />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/creators/:username"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={Profile} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/profile"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <Profile {...routeProps} {...props} />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/account-status"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={AccounStatus} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/edit-profile"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={EditProfile}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/teams/:groupname"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={Team} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/:groupname/edit-team"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={EditTeam}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <ProtectedRoute path="/profile" component={Profile} {...props} />
 
-        <Route
-          path="/projects/staff-picks/:id"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={StaffPickDetails}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/edit-profile"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={EditProfile} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/projects/create"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={CreateProject}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/:groupname/edit-team"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={EditTeam} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/projects/saved"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={SavedProjects}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
-        <Route
-          path="/projects/:id/edit"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={CreateProject}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
-        <Route
-          path="/projects/:activity_id/create"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={CreateProject}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
-        <Route
-          path="/projects/:id"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={ProjectDetails}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/projects/staff-picks/:id"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={StaffPickDetails} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/ambassadors"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={Ambassadors}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/projects/create"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={CreateProject} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/privacy_policy"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={Guidelines}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/projects/saved"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={SavedProjects} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
+          <Route
+            path="/projects/:id/edit"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={CreateProject} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
+          <Route
+            path="/projects/:activity_id/create"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={CreateProject} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/terms_of_use"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={TermsOfUse}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          {/* <ProtectedRoute path="/profile" component={ProjectDetails} {...props} /> */}
+          <ProtectedRoute
+            path="/projects/:id"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={ProjectDetails} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/about"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport LazyComponent={About} {...routeProps} {...props} />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/ambassadors"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={Ambassadors} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/challenge"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={Challenge}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/privacy_policy"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={Guidelines} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/faqs"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport LazyComponent={FAQs} {...routeProps} {...props} />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/terms_of_use"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={TermsOfUse} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/activities/:id/edit"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={CreateActivity}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/about"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={About} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/activities/:id"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={ActivityDetails}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/challenge"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={Challenge} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/activities"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={Activities}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/faqs"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={FAQs} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="/create-team"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport
-                LazyComponent={CreateTeam}
-                {...routeProps}
-                {...props}
-              />
-            </PageWrapper>
-          )}
-        />
+          <Route
+            path="/activities/:id/edit"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={CreateActivity} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
 
-        <Route
-          path="*"
-          render={routeProps => (
-            <PageWrapper {...routeProps} {...props}>
-              <LazyImport LazyComponent={NotFound} {...routeProps} />
-            </PageWrapper>
-          )}
-        />
-      </Switch>
-    </Router>
+          <Route
+            path="/activities/:id"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={ActivityDetails} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
+
+          <Route
+            path="/activities"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={Activities} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
+
+          <Route
+            path="/create-team"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={CreateTeam} {...routeProps} {...props} />
+              </PageWrapper>
+            )}
+          />
+
+          <Route
+            path="*"
+            render={routeProps => (
+              <PageWrapper {...routeProps} {...props}>
+                <LazyImport LazyComponent={NotFound} {...routeProps} />
+              </PageWrapper>
+            )}
+          />
+        </Switch>
+      </Router>
     </ThemeContext.Provider>
   );
 }
 
-export default withTranslation()(App);
+const mapStateToProps = state => {
+  return {
+    auth: state.auth,
+  };
+};
+
+const ConnectedApp = connect(mapStateToProps)(App);
+
+export default withTranslation()(ConnectedApp);

--- a/zubhub_frontend/zubhub/src/App.js
+++ b/zubhub_frontend/zubhub/src/App.js
@@ -6,6 +6,7 @@ import { useEffect } from 'react';
 import { connect } from 'react-redux';
 import LoadingPage from './views/loading/LoadingPage';
 import PageWrapper from './views/PageWrapper';
+import ProtectedRoute from './components/protected_route/ProtectedRoute';
 import ZubhubAPI from '../src/api/api';
 import { updateTheme } from './theme';
 import ScrollToTop from './ScrollToTop';
@@ -61,23 +62,6 @@ const LazyImport = props => {
     <React.Suspense fallback={<LoadingPage />}>
       <LazyComponent {...restOfProps} />
     </React.Suspense>
-  );
-};
-
-const ProtectedRoute = ({ component: LazyComponent, ...props }) => {
-  return (
-    <Route
-      {...props}
-      render={routeProps =>
-        props.auth?.token ? (
-          <PageWrapper {...props} {...routeProps}>
-            <LazyImport LazyComponent={LazyComponent} {...routeProps} {...props} />
-          </PageWrapper>
-        ) : (
-          <Redirect to="/login" />
-        )
-      }
-    />
   );
 };
 

--- a/zubhub_frontend/zubhub/src/components/protected_route/ProtectedRoute.jsx
+++ b/zubhub_frontend/zubhub/src/components/protected_route/ProtectedRoute.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { Redirect, Route } from 'react-router-dom'
+import PageWrapper from '../../views/PageWrapper';
+import LoadingPage from '../../views/loading/LoadingPage';
+
+const ProtectedRoute = ({ component: LazyComponent, ...props }) => {
+    return (
+      <Route
+        {...props}
+        render={routeProps =>
+          props.auth?.token ? (
+            <PageWrapper {...props} {...routeProps}>
+              <React.Suspense fallback={<LoadingPage />}>
+                <LazyComponent {...routeProps} {...props} />
+              </React.Suspense>
+            </PageWrapper>
+          ) : (
+            <Redirect to="/login" />
+          )
+        }
+      />
+    );
+  };
+
+  export default ProtectedRoute

--- a/zubhub_frontend/zubhub/src/views/profile/Profile.jsx
+++ b/zubhub_frontend/zubhub/src/views/profile/Profile.jsx
@@ -46,7 +46,7 @@ import {
   handleToggleDeleteAccountModal,
   deleteAccount,
   getUserTeams,
-  followTeam
+  followTeam,
 } from './profileScripts';
 
 import CustomButton from '../../components/button/Button';
@@ -82,8 +82,8 @@ function Profile(props) {
   const [page, setPage] = useState(1);
   const [userActivity, setUserActivity] = useState([]);
   const [scrollPosition, setScrollPosition] = useState(0);
-  const [nextPage, setNextPage] = useState(false)
-  const [teams, setTeams] = useState([])
+  const [nextPage, setNextPage] = useState(false);
+  const [teams, setTeams] = useState([]);
   const [state, setState] = React.useState({
     results: [],
     loading: true,
@@ -94,30 +94,31 @@ function Profile(props) {
     drafts: [],
     badge_tags: [],
   });
-  React.useEffect(() => {
-  try{
-    let activitylogObj= new API()
-    const promises = [getUserProfile(props), getUserTeams(props), activitylogObj.getUserActivity(username, page)];
-    if (username === props.auth.username) {
-      promises.push(
-        ProjectActions.getUserDrafts({
-          username,
-          token: props.auth.token,
-          t: props.t,
-          limit: 4,
-        }),
-      );
-    }
 
-    Promise.all(promises).then(values => {
-      const obj = values[0];
-      const team = values[1].results;
-      // setTeams(team);
-      // setTeams(teams   => ([...teams, ...team]));
-      handleSetTeams(team); 
-      const activity = values[2] || {};
-      const drafts = values[3] || {};
-      const badges = obj.profile.badges;
+  React.useEffect(() => {
+    try {
+      let activitylogObj = new API();
+      const promises = [getUserProfile(props), getUserTeams(props), activitylogObj.getUserActivity(username, page)];
+      if (username === props.auth.username) {
+        promises.push(
+          ProjectActions.getUserDrafts({
+            username,
+            token: props.auth.token,
+            t: props.t,
+            limit: 4,
+          }),
+        );
+      }
+
+      Promise.all(promises).then(values => {
+        const obj = values[0];
+        const team = values[1].results;
+        // setTeams(team);
+        // setTeams(teams   => ([...teams, ...team]));
+        handleSetTeams(team);
+        const activity = values[2] || {};
+        const drafts = values[3] || {};
+        const badges = obj.profile.badges;
 
         if (obj.profile) {
           parseComments(obj.profile.comments);
@@ -141,7 +142,7 @@ function Profile(props) {
   };
 
   const handleSetTeams = newTeams => {
-    setTeams(teams => [...teams, ...newTeams]);
+    newTeams && setTeams(teams => [...teams, ...newTeams]);
   };
 
   const {
@@ -300,19 +301,12 @@ function Profile(props) {
             <Typography gutterBottom component="h2" variant="h6" color="textPrimary" className={classes.titleStyle}>
               {t('profile.activityLog.activity')}
             </Typography>
-                  <div onScroll= {handleScroll} style= {{maxHeight: '300px', overflow: 'auto'}}>
-
-                    {
-                      userActivity.length ? 
-                      userActivity.map(activity => (
-                        <UserActivitylog 
-                        activity={activity}
-                        key={activity.id}
-                        />
-                        )) : (<Box>{t('profile.activityLog.addActivityLog')}</Box>)
-                      }
-                  </div>
-            </Paper>
+            <div onScroll={handleScroll} style={{ maxHeight: '300px', overflow: 'auto' }}>
+              {userActivity.map(activity => (
+                <UserActivitylog activity={activity} key={activity.id} />
+              ))}
+            </div>
+          </Paper>
 
             {TEAM_ENABLED== true ? (<Paper   className= {classes.profileLowerStyle}>
             <Typography
@@ -322,7 +316,7 @@ function Profile(props) {
              color="textPrimary"
              className= {classes.titleStyle}
             >
-            {t('profile.teams')}
+            {t('Teams')}
             <CustomButton
               className={classes.teamButton}
               variant="contained"
@@ -335,55 +329,43 @@ function Profile(props) {
             </Typography>
             <Grid container spacing={2}>
                 {teams.map(team => (
-                  <Grid
-                    item
-                    xs={12}
-                    sm={6}
-                    md={6}
-                    className={classes.projectGridStyle}
-                    align="center"
-                  > 
-                  
-                  <Link to={`/teams/${team.groupname}`} className={classes.textDecorationNone}>
-                    <Card>
-                      <CardContent className={classes.mediaBoxStyle}>
-                        <Avatar
-                          className={classes.creatorAvatarStyle}
-                          src={team.avatar}
-                          alt={team.groupname}
-                        />
-                        <Typography className={classes.titleStyle} variant="h5" component="h2">
-                          {team.groupname}
-                        </Typography>
-                        <Typography
-                          className={classes.descriptionStyle}
-                          variant="subtitle2"
-                          color="textSecondary"
-                          component="p"
-                        >
-                          {team.description}
-                        </Typography>
-                        <CustomButton
-                          className={classes.followButton}
-                          variant="outlined"
-                          margin="normal"
-                          secondaryButtonStyle
-                          onClick={() => followTeam(team.groupname, props.auth.username, props)}
-                          style={{
-                            fontSize: '12px', // Adjust the font size as needed
-                            padding: '6px 12px', // Adjust the padding to change the button size
-                          }}
-                        >
-                          {team.members.includes(props.auth.id) ? t('profile.unfollow') : t('profile.follow')}
-                        </CustomButton>
-                      </CardContent>
-                    </Card>
-                  </Link>
-
+                  <Grid item xs={12} sm={6} md={6} className={classes.projectGridStyle} align="center">
+                    <Link to={`/teams/${team.groupname}`} className={classes.textDecorationNone}>
+                      <Card>
+                        <CardContent className={classes.mediaBoxStyle}>
+                          <Avatar className={classes.creatorAvatarStyle} src={team.avatar} alt={team.groupname} />
+                          <Typography className={classes.titleStyle} variant="h5" component="h2">
+                            {team.groupname}
+                          </Typography>
+                          <Typography
+                            className={classes.descriptionStyle}
+                            variant="subtitle2"
+                            color="textSecondary"
+                            component="p"
+                          >
+                            {team.description}
+                          </Typography>
+                          <CustomButton
+                            className={classes.followButton}
+                            variant="outlined"
+                            margin="normal"
+                            secondaryButtonStyle
+                            onClick={() => followTeam(team.groupname, props.auth.username, props)}
+                            style={{
+                              fontSize: '12px', // Adjust the font size as needed
+                              padding: '6px 12px', // Adjust the padding to change the button size
+                            }}
+                          >
+                            {team.members.includes(props.auth.id) ? t('profile.unfollow') : t('profile.follow')}
+                          </CustomButton>
+                        </CardContent>
+                      </Card>
+                    </Link>
                   </Grid>
                 ))}
               </Grid>
-            </Paper>):null}
+            </Paper>
+          ) : null}
 
           {profile.projects_count > 0 || drafts.length > 0 ? (
             username === props.auth.username ? (


### PR DESCRIPTION
## Summary
Instead showing of show a `404` error page to routes that do exist but actually just require authentication ie for a user to be logged in.
Closes 

## Changes

- Added `route protection` component

## API
- **Path**: `string`
     Route to which the a given component will be rendered

- **Component**: `React.component`
     A react component that's to be rendered with the `path`

`<ProtectedRoute path='/home' component={Home} {...props} />`

## Notes
  - Don't forget to path a distructured `props` object. It contains vitals properties for the application to run

## Screencasts
[Screencast from 2023-10-06 16-05-59.webm](https://github.com/unstructuredstudio/zubhub/assets/141822315/4147f8c1-3f30-417d-a004-ef5cb50b4f5c)


