### PR TITLE
fix sidenav to view port

### DIFF
--- a/zubhub_frontend/zubhub/src/components/Sidenav/sidenav.styles.js
+++ b/zubhub_frontend/zubhub/src/components/Sidenav/sidenav.styles.js
@@ -3,10 +3,10 @@ import { colors } from "../../assets/js/colors";
 export const sidenavStyle = theme => ({
     container: {
         backgroundColor: 'white',
-        minHeight: '80vh',
+        minHeight: '65vh',
         display: 'flex',
         borderRadius: 8,
-
+        position: 'fixed',
         [theme.breakpoints.down('sm')]: {
             height: '100%',
         },


### PR DESCRIPTION
## Summary

Fixed Sidenav to the viewport. User does not have to scroll all the way up to create a project. 

## Changes

- Sidenav position fixed.
- Sidenav height reduced so it does not collapse with footer.

## Screenshots

![Screenshot from 2023-10-09 17-04-04](https://github.com/unstructuredstudio/zubhub/assets/85514520/8b4d3249-6e2e-4a04-a1dd-64fdaca03206)

