### PR TITLE
fix: debug toolbar dependency issue fixed

### DIFF
--- a/zubhub_backend/compose/celery/requirements.txt
+++ b/zubhub_backend/compose/celery/requirements.txt
@@ -20,7 +20,7 @@ django-celery-email>=3.0.0
 django-celery-results>=2.0.0
 django-cors-headers>=3.1.1
 django-crispy-forms>=1.8.0
-django-debug-toolbar>=2.0
+django-debug-toolbar==3.4.0
 django-extensions==3.1.5
 django-js-asset>=1.2.2
 django-mptt>=0.11.0

--- a/zubhub_backend/compose/flower/requirements.txt
+++ b/zubhub_backend/compose/flower/requirements.txt
@@ -20,7 +20,7 @@ django-celery-email>=3.0.0
 django-celery-results>=2.0.0
 django-cors-headers>=3.1.1
 django-crispy-forms>=1.8.0
-django-debug-toolbar>=2.0
+django-debug-toolbar==3.4.0
 django-js-asset>=1.2.2
 django-mptt>=0.11.0
 django-rest-auth>=0.9.5

--- a/zubhub_backend/compose/web/requirements.txt
+++ b/zubhub_backend/compose/web/requirements.txt
@@ -21,7 +21,7 @@ django-celery-results>=2.0.0
 django-cors-headers>=3.1.1
 django-crispy-forms>=1.8.0
 django-extensions==3.1.5
-django-debug-toolbar>=2.0
+django-debug-toolbar==3.4.0
 django-js-asset>=1.2.2
 django-mptt>=0.11.0
 django-rest-auth>=0.9.5


### PR DESCRIPTION
## Summary

Description of PR here...
Closes #861 

## Changes

- changes to `requirements.txt`

```txt
...
+ django-debug-toolbar==3.4.0
...
```
