### PR TITLE
fix: makes back button for projects work

### DIFF
--- a/zubhub_frontend/zubhub/src/views/create_project/CreateProject.jsx
+++ b/zubhub_frontend/zubhub/src/views/create_project/CreateProject.jsx
@@ -258,7 +258,9 @@ function CreateProject(props) {
       </Dialog>
       {/* Banner */}
       <Box className={classes.banner}>
-        <KeyboardBackspaceRoundedIcon />
+        <Link href="/projects" color="inherit" className={classes.backLink}>
+          <KeyboardBackspaceRoundedIcon/>
+        </Link>
         {props.match.params.id && (
           <>
             <CustomButton onClick={togglePreview} className={classes.previewButton} variant="outlined">


### PR DESCRIPTION
## Summary

Description of PR here...
Closes #846 

## Changes

- Wrapping the icon into a link component
```jsx
<Link href="/projects" color="inherit" className={classes.backLink}>
  <KeyboardBackspaceRoundedIcon/>
</Link>
```