### PR TITLE
feat: add additional password validation on Signup

### DIFF
--- a/zubhub_frontend/zubhub/public/locales/en/translation.json
+++ b/zubhub_frontend/zubhub/public/locales/en/translation.json
@@ -117,7 +117,7 @@
           "min": "Your password seems too short",
           "upper-caps": "Your password must contain at least 1 uppercase character",
           "lower-caps": "Your password must contain at least 1 lowercase character",
-          "digit": "Your password must contain at least digit",
+          "digit": "Your password must contain at least 1 digit",
           "special": "Your password must contain at least 1 special character",
           "required": "Provide a strong password here!"
         }

--- a/zubhub_frontend/zubhub/public/locales/en/translation.json
+++ b/zubhub_frontend/zubhub/public/locales/en/translation.json
@@ -115,6 +115,10 @@
         "label": "Password",
         "errors": {
           "min": "Your password seems too short",
+          "upper-caps": "Your password must contain at least 1 uppercase character",
+          "lower-caps": "Your password must contain at least 1 lowercase character",
+          "digit": "Your password must contain at least digit",
+          "special": "Your password must contain at least 1 special character",
           "required": "Provide a strong password here!"
         }
       },

--- a/zubhub_frontend/zubhub/src/views/signup/signupScripts.js
+++ b/zubhub_frontend/zubhub/src/views/signup/signupScripts.js
@@ -235,7 +235,12 @@ export const validationSchema = Yup.object().shape({
     }),
   dateOfBirth: Yup.date().max(new Date(new Date().getFullYear() - 12, 1, 1), 'oldEnough').required('required'),
   user_location: Yup.string().min(1, 'min').required('required'),
-  password1: Yup.string().min(8, 'min').required('required'),
+  password1: Yup.string()
+  .min(8, 'min').required('required')
+  .matches(/[A-Z]/, 'upper-caps').required('required')
+  .matches(/[a-z]/, 'lower-caps').required('required')
+  .matches(/[0-9]/, 'digit').required('required')
+  .matches(/[!@#$%^&*]/, 'special').required('required'),
   password2: Yup.string()
     .oneOf([Yup.ref('password1'), null], 'noMatch')
     .required('required'),


### PR DESCRIPTION
## Summary

Requiring strong passwords on all websites is a standard practice for enhancing security. Currently, Zubhub only has password validation on signup for passwords based on length. I have added password validation on signup for.

- At least 1 upper-case character.
- At least 1 lower-case character.
- At least 1 digit.
- At least one special character ("!", "@", "#", "$", "%", "^", "&", "*")


## Screenshots

![Screenshot from 2023-10-13 19-58-07](https://github.com/unstructuredstudio/zubhub/assets/85514520/2e8acbd7-8cfa-4c94-87f9-1476f90d18b0)
![Screenshot from 2023-10-13 19-36-27](https://github.com/unstructuredstudio/zubhub/assets/85514520/001ae030-c449-4603-af58-36b9dfc40a3c)
![Screenshot from 2023-10-13 20-00-08](https://github.com/unstructuredstudio/zubhub/assets/85514520/fdb98c30-72d0-4b54-90ef-1bf8e68bcfa4)
![Screenshot from 2023-10-13 19-37-05](https://github.com/unstructuredstudio/zubhub/assets/85514520/8624d518-5507-4522-8ede-915aab421a0d)
