### PR TITLE
(enhancement) Utilize client-side routing provided by `react-router-dom` in the SideNav links

### DIFF
--- a/zubhub_frontend/zubhub/src/components/Sidenav/Sidenav.jsx
+++ b/zubhub_frontend/zubhub/src/components/Sidenav/Sidenav.jsx
@@ -1,6 +1,5 @@
 import {
   CircularProgress,
-  Link,
   List,
   ListItem,
   ListItemIcon,
@@ -12,7 +11,7 @@ import clsx from 'clsx';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
-import { useHistory, useLocation } from 'react-router-dom';
+import { useHistory, useLocation, Link } from 'react-router-dom';
 import API from '../../api';
 import { images } from '../../assets/images';
 import { logout } from '../../store/actions/authActions';
@@ -67,7 +66,7 @@ export default function Sidenav() {
     <div className={classes.container}>
       <List className={classes.listContainer}>
         {isSmallScreen && (
-          <Link className={clsx(classes.logo, classes.link)} href="/">
+          <Link className={clsx(classes.logo, classes.link)} to="/">
             <ListItem>
               <img alt="Zubhub Logo" src={images.logo} />
             </ListItem>
@@ -82,7 +81,7 @@ export default function Sidenav() {
                   <Link
                     key={index + label}
                     className={clsx(classes.label, classes.link, pathname === link && classes.active, red && classes.red)}
-                    href={link}
+                    to={link}
                     target={target || '_self'}
                   >
                     <ListItem key={label}>
@@ -114,7 +113,7 @@ export default function Sidenav() {
                   <Link
                     key={index + label}
                     className={clsx(classes.label, classes.link, pathname == link && classes.active, red && classes.red)}
-                    href={link}
+                    to={link}
                     target={target || '_self'}
                   >
                     <ListItem key={label}>
@@ -138,7 +137,7 @@ export default function Sidenav() {
                 key={index + label}
                 className={clsx(classes.label, classes.link, pathname == link && classes.active, red && classes.red)}
                 style={{ marginTop: index == 0 && 'auto' }}
-                {...(link && { href: link })}
+                {...(link && { to: link })}
                 onClick={action == 'logout' ? handleLogout : null}
               >
                 <ListItem key={label}>


### PR DESCRIPTION
## Summary
When you use the Link component from react-router-dom to create navigation links, it ensures that the navigation happens without a full page refresh. Instead of requesting a new HTML page from the server, React updates the DOM efficiently by re-rendering only the components necessary for the new route. This approach provides a smoother and faster user experience because it doesn't reload the entire page, making web applications feel more like native applications.

## Changes
- Uses react-router-dom's Link component instead of material UI's.

## Screencasts

### Before
[Screencast from 2023-10-26 23-02-49.webm](https://github.com/unstructuredstudio/zubhub/assets/141822315/73ef582a-4121-470c-b868-29bf12408e94)

### After
[Screencast from 2023-10-26 23-03-24.webm](https://github.com/unstructuredstudio/zubhub/assets/141822315/d87e7443-ed21-4531-b103-fc036ef503e0)
