### PR TITLE
(fix) Prevent member duplication when creating a `Team`

### DIFF
--- a/zubhub_frontend/zubhub/src/views/create_team/step2/Step2.jsx
+++ b/zubhub_frontend/zubhub/src/views/create_team/step2/Step2.jsx
@@ -17,6 +17,10 @@ export default function Step2({ formik }) {
   const [adminSuggestions, setAdminSuggestions] = useState([]);
   const [memberSuggestions, setMemberSuggestions] = useState([]);
 
+  const { values: { members, admins} } = formik
+
+  const allMembers = [...(admins ? admins : []), ...(members ? members : [])]
+
   const handleAdminSelect = (event, value) => {
     setSelectedAdmins(value);
     setAdminsInputValue('');
@@ -35,12 +39,17 @@ export default function Step2({ formik }) {
     // Perform API call to get admin suggestions based on the input value
     try {
       const completions = await api.autocompleteCreators({ query: value });
-      const suggestions = completions.map(({ username, avatar }) => ({
+      const suggestions = completions.map(({ username, avatar, id }) => ({
         title: username,
         image: avatar,
         link: `/creators/${username}`,
+        id
       }));
-      setAdminSuggestions(suggestions);
+      
+      const filteredSuggestions = suggestions.filter(({ id }) => 
+        !allMembers.some(member => member.id === id)
+      );
+      setAdminSuggestions(filteredSuggestions);
     } catch (error) {
       console.error('Error fetching admin suggestions:', error);
       setAdminSuggestions([]);
@@ -54,12 +63,17 @@ export default function Step2({ formik }) {
     // Perform API call to get member suggestions based on the input value
     try {
       const completions = await api.autocompleteCreators({ query: value });
-      const suggestions = completions.map(({ username, avatar }) => ({
+      const suggestions = completions.map(({ username, avatar, id }) => ({
         title: username,
         image: avatar,
         link: `/creators/${username}`,
+        id
       }));
-      setMemberSuggestions(suggestions);
+
+      const filteredSuggestions = suggestions.filter(({ id }) => 
+        !allMembers.some(member => member.id === id)
+      );
+      setMemberSuggestions(filteredSuggestions);
     } catch (error) {
       console.error('Error fetching member suggestions:', error);
       setMemberSuggestions([]);


### PR DESCRIPTION
## Summary
Prevents member duplication when creating a team

## Changes
- filters out already selected members from suggestions

## Screencasts
[Screencast from 2023-11-09 10-17-35.webm](https://github.com/unstructuredstudio/zubhub/assets/141822315/ca6e61b3-0c3e-4ecb-a2a7-1b3c6c7b1fef)
