### PR TITLE
Feat/984: Add Edit Profile to the sidenav

### DIFF
--- a/zubhub_frontend/zubhub/public/locales/en/translation.json
+++ b/zubhub_frontend/zubhub/public/locales/en/translation.json
@@ -34,7 +34,7 @@
     },
     "sidebar":{
       "logout": "Logout",
-      "expoloreActivities":"Explore Activities",
+      "exploreActivities":"Explore Activities",
       "teams":"Teams",
       "bookmarks":"Bookmarks",
       "myProjects":"My Projects",
@@ -43,7 +43,8 @@
       "createProject":"Create Project",
       "profile":"My Profile",
       "projects":"All Projects",
-      "settings":"Settings"
+      "settings":"Settings",
+      "editProfile": "Account Settings"
     },
 
     "footer": {

--- a/zubhub_frontend/zubhub/public/locales/hi/translation.json
+++ b/zubhub_frontend/zubhub/public/locales/hi/translation.json
@@ -32,7 +32,20 @@
       "unpublishedActivities": "अप्रकाशित गतिविधियाँ",
       "myActivities": "मेरी गतिविधियां"
     },
-
+    "sidebar": {
+      "logout": "लॉगआउट",
+      "exploreActivities": "गतिविधियाँ करें",
+      "teams": "टीमें",
+      "bookmarks": "बुकमार्क्स",
+      "myProjects": "मेरे परियोजनाएँ",
+      "myDrafts": "मेरे मसौदे",
+      "createActivity": "गतिविधि बनाएं",
+      "createProject": "परियोजना बनाएं",
+      "profile": "मेरी प्रोफ़ाइल",
+      "projects": "सभी परियोजनाएँ",
+      "settings": "सेटिंग्स",
+      "editProfile": "खाता सेटिंग्स"
+    },    
     "footer": {
       "privacy": "एकांत",
       "guidelines": "गोपनीयता नीति",
@@ -825,7 +838,7 @@
       }
     },
     "actions": {
-      "submit": "परिवर्तनों को सुरक्षित करें",
+      "submit": "परिवर्तनों को सुरक्षित करें"
     },
     "delete": {
       "label": "टीम हटाएं",

--- a/zubhub_frontend/zubhub/src/components/Sidenav/data.js
+++ b/zubhub_frontend/zubhub/src/components/Sidenav/data.js
@@ -36,7 +36,8 @@ export const links = ({ draftCount, myProjectCount, auth, t }) => [
     },
     { label: t('pageWrapper.sidebar.bookmarks'), link: '/projects/saved', icon: Bookmark, requireAuth: true },
     ...(TEAM_ENABLED ? [{ label: t('pageWrapper.sidebar.teams'), link: '/teams/all', icon: RiTeamFill }] : []),
-    { label: t('pageWrapper.sidebar.expoloreActivities'), link: 'https://kriti.unstructured.studio/', target: '_blank', icon: FeaturedPlayList },
+    { label: t('pageWrapper.sidebar.exploreActivities'), link: 'https://kriti.unstructured.studio/', target: '_blank', icon: FeaturedPlayList },
+    { label: t('pageWrapper.sidebar.editProfile'), link: '/edit-profile', icon: Settings, reactIcon: true, requireAuth: true },
 ];
 
 export const bottomLinks = ({ t }) => [


### PR DESCRIPTION
## Summary

The edit profile section has its own button on the Sidenav. 
Some work needs to be done to change the design of the edit profile section. Waiting for #968 (which is implementing the reset password feature) to be merged to work on the design.

Closes #984 

## Changes

- One Item added to Sidenav named `Account Settings`
- Translation strings added for all the menu items in the navbar.
- Fixed a typo in `Explore Activities` item in Sidenav which was preventing its translation to Hindi.

## Screenshots

![Screenshot from 2023-11-16 01-55-24](https://github.com/unstructuredstudio/zubhub/assets/85514520/effb4437-a4e5-4383-b28e-fc4819e97e0b)
![Screenshot from 2023-11-16 01-55-12](https://github.com/unstructuredstudio/zubhub/assets/85514520/ae60b982-2f80-4f9b-a532-d95f712f11ab)


