### PR TITLE
Fix failing tests for new contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ $ docker cp <container ID>:/etc/rabbitmq/rabbitmq.conf .
 ```sh
 $ docker cp rabbitmq.conf <container ID>:/etc/rabbitmq/rabbitmq.conf
 ```
-6. Run `make init`, and then run `make test` again.
+6. Restart the container, and then run `make test` again.
 
 **Note**: Alternatively, if you have a text editor configured with your Docker, you could just do only step 4 and then restart the container. 
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,25 @@ To stop:
 ```
 
 You can run test by running `make test`.
+> **_NOTE_**: While running tests, follow these steps if you encounter an error whose last line in the traceback is: 
+```sh
+amqp.exceptions.AccessRefused: (0, 0): (403) ACCESS_REFUSED - Login was refused using authentication mechanism AMQPLAIN. For details see the broker logfile.
+```
+1. From the command line, get the rabbitmq container id from the list of running containers and copy it. You can get the list by running: ```$ docker ps```
+2. Copy the configuration file from the docker container to a path in your local machine you can use:
+```sh
+$ docker cp <container ID>:/etc/rabbitmq/rabbitmq.conf .
+```
+3. Open the `rabbitmq.conf` file from where you've copied it to in your local machine, with a text editor. 
+4. Change `loopback_users.admin` to `false`, save the file, and then close it.
+5. Copy the `rabbitmq.conf` back to its original location in the container. You can do this via:
+```sh
+$ docker cp rabbitmq.conf <container ID>:/etc/rabbitmq/rabbitmq.conf
+```
+6. Run `make init`, and then run `make test` again.
+
+**Note**: Alternatively, if you have a text editor configured with your Docker, you could just do only step 4 and then restart the container. 
+
 For other make commands: run **make help**
 
 Visit http://localhost:8000 on your browser to access the API documentation.

--- a/zubhub_backend/.gitignore
+++ b/zubhub_backend/.gitignore
@@ -11,3 +11,9 @@ cadvisor.htpasswd
 .ssl-data
 celerybeat-schedule
 celerybeat.pid
+# Ignore package.json and package-lock.json files
+**/package.json
+**/package-lock.json
+# Ignore Pipfile and Pipfile.lock files
+**/Pipfile
+**/Pipfile.lock


### PR DESCRIPTION
Fixes #1018 

## Summary

This PR provides steps in the `README.md` to resolve the issue of already-existing tests failing because of an autogenerated faulty `rabbitMQ` configuration.
It also adds dependency managers to the backend `.gitignore` file, because the `package.json`,  `package-lock.json`, `Pipfile`, and `Pipfile.lock` are autogenerated as well.

## Screenshots
A screenshot of the tests now passing after following the guide:

<img width="506" alt="image" src="https://github.com/unstructuredstudio/zubhub/assets/29470516/b165d745-352f-4d6a-ac8a-b38043b3eb7e">

A screenshot that shows a successful login to the `localhost:15672`
<img width="943" alt="image" src="https://github.com/unstructuredstudio/zubhub/assets/29470516/51c3cd88-c8d9-444a-b3d5-76c809708aff">

A screenshot of the `rabbitmq` docker logs:
<img width="775" alt="image" src="https://github.com/unstructuredstudio/zubhub/assets/29470516/d86b35af-b3a9-48cd-ab46-044291cd3a07">

