### PR TITLE
fix broken deployment

### DIFF
--- a/zubhub_backend/docker-compose.prod.yml
+++ b/zubhub_backend/docker-compose.prod.yml
@@ -69,7 +69,8 @@ services:
       SITES:
         "api.zubhub.unstructured.studio=web:8000;www.api.zubhub.unstructured.studio=web:8000;\
         media.zubhub.unstructured.studio=media:8001;\
-        rabbitmq.zubhub.unstructured.studio=rabbitmq:15672;prometheus.zubhub.unstructured.studio=prometheus:9090"
+        rabbitmq.zubhub.unstructured.studio=rabbitmq:15672"
+      # ;prometheus.zubhub.unstructured.studio=prometheus:9090"
       FORCE_HTTPS: "true"
     depends_on:
       - web


### PR DESCRIPTION
we recently commented out prometheus section from our docker-compose (because it's unused) but forgot to remove prometheus domain from `SITES` in nginx-auto-ssl load-balancer container config. As a result of this oversight our domain has been down. Removing this domain from `SITES` fixed the issue.
