### PR TITLE
docker system prune action Iteration=3

### DIFF
--- a/.github/workflows/build_deploy_backend.yml
+++ b/.github/workflows/build_deploy_backend.yml
@@ -101,6 +101,6 @@ jobs:
             while IFS= read -r volume; do
               # Delete the volume if it doesn't end with "_data"
               if [[ ! $volume =~ _data$ ]]; then
-                docker volume rm "$volume" 2> /dev/null
+                docker volume rm "$volume" 2> /dev/null || true
               fi
             done <<< "$volumes"

--- a/.github/workflows/build_deploy_frontend.yml
+++ b/.github/workflows/build_deploy_frontend.yml
@@ -71,6 +71,6 @@ jobs:
             while IFS= read -r volume; do
               # Delete the volume if it doesn't end with "_data"
               if [[ ! $volume =~ _data$ ]]; then
-                docker volume rm "$volume" 2> /dev/null
+                docker volume rm "$volume" 2> /dev/null || true
               fi
             done <<< "$volumes"


### PR DESCRIPTION
use `docker volume rm "$volume" 2> /dev/null || true` so an error (like volume still in use) won't cause action to exit with 1

Issue: #1030