### PR TITLE
create_destory_test_vm minor improvement

### DIFF
--- a/.github/workflows/create_destroy_test_vm.yaml
+++ b/.github/workflows/create_destroy_test_vm.yaml
@@ -276,7 +276,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
           message: |
-            Test VM is ready ✔✔✔
+            Test VM is ready ✅✅✅
             You can access it with the url:
             https://${{env.FRONTEND_DOMAIN}}.unstructured.studio
 ######################################################################################
@@ -380,5 +380,5 @@ jobs:
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
           message: |
-            Test VM deleted ✔✔✔
+            Test VM deleted ✅✅✅
 ######################################################################################

--- a/.github/workflows/create_destroy_test_vm.yaml
+++ b/.github/workflows/create_destroy_test_vm.yaml
@@ -286,12 +286,14 @@ jobs:
 ##################################################################################
   destroy_test_vm:
     if: |
-      github.event.action == 'closed' ||
-      (github.event.action == 'unlabeled' && github.event.label.name == 'create-test-vm') ||
       (
-        github.event.action == 'reopened' ||
-        github.event.action == 'synchronize'
-      ) && contains(github.event.pull_request.labels.*.name, 'create-test-vm') != true
+        github.event.action == 'closed' &&
+        contains(github.event.pull_request.labels.*.name, 'create-test-vm')
+      ) ||
+      (
+        github.event.action == 'unlabeled' &&
+        github.event.label.name == 'create-test-vm'
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Get pr number and droplet ip


### PR DESCRIPTION
improve the conditions of `destroy_test_vm` to only run
when:
* pr is closed and PR still has the `create-test-vm` label
* `create-test-vm` label is removed from PR

This ensures that the `destory_test_vm` only runs when
neccessary and doesn't spam the github actions tab.

issue: #1030 
Signed-off-by: Ndibe Raymond Olisaemeka <rolisaemeka-ctr@wikimedia.org>
