### PR TITLE
refactor: changes from youtube to no-cookies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 pre-commit-venv
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 pre-commit-venv
-.idea/

--- a/zubhub_backend/Makefile
+++ b/zubhub_backend/Makefile
@@ -98,7 +98,7 @@ default-theme:
 	docker-compose -f docker-compose.yml exec web bash -c "python zubhub/manage.py create_default_theme"
 .PHONY: default-theme
 
-init: .env start migrate admin-user add-theme ## Initialize docker-compose containers
+init: .env start migrate admin-user default-theme ## Initialize docker-compose containers
 .PHONY: init
 
 search-index:

--- a/zubhub_frontend/zubhub/src/components/input/inputScripts.js
+++ b/zubhub_frontend/zubhub/src/components/input/inputScripts.js
@@ -1,7 +1,8 @@
 export const refactorVideoUrl = url => {
   if (url.includes('youtube.com')) {
     url = url.split('&')[0];
-    return url.replace('watch?v=', 'embed/');
+    url = url.replace('watch?v=', 'embed/');
+    return url.replace('youtube.com', 'youtube-nocookie.com');
   } else {
     if (url.includes('youtu.be')) {
       return 'https://www.youtube-nocookie.com/embed/'.concat(url.split('/')[3]);

--- a/zubhub_frontend/zubhub/src/components/input/inputScripts.js
+++ b/zubhub_frontend/zubhub/src/components/input/inputScripts.js
@@ -4,7 +4,7 @@ export const refactorVideoUrl = url => {
     return url.replace('watch?v=', 'embed/');
   } else {
     if (url.includes('youtu.be')) {
-      return 'https://www.youtube.com/embed/'.concat(url.split('/')[3]);
+      return 'https://www.youtube-nocookie.com/embed/'.concat(url.split('/')[3]);
     }
     if (url.includes('drive.google.com')) {
       if (url.includes('/view')) {


### PR DESCRIPTION
## Summary

Description of PR here...
Closes #1079 

## Changes
- The preload link was changed from `https//www.youtube.com` to `https://www.youtube-nocookie.com`
- Changes the theme command in the `make init` for the backend

## References
- [Stackoverflow](https://stackoverflow.com/questions/66099180/react-js-error-the-service-worker-navigation-preload-request-was-cancelled-befo)