### PR TITLE
Redesign Activity Details Page

### DIFF
--- a/zubhub_frontend/zubhub/public/locales/en/translation.json
+++ b/zubhub_frontend/zubhub/public/locales/en/translation.json
@@ -1098,7 +1098,8 @@
          "mediaServerError": "Sorry media server is down we couldn't upload your files! try again later",
          "uploadError": "error occurred while downloading file : "
       }
-   }
+   },
+   "tooltipMore": " more"
  },
 
   "activityDetails": {
@@ -1112,11 +1113,18 @@
        "contributors": "CONTRIBUTORS"
     },
     "made": "Made by",
+    "inspired": {
+      "recreated": "Re-created",
+      "times": "times"
+    },
     "activity": {
       "creator": {
         "follow": "Follow",
         "unfollow": "Unfollow"
       },
+      "introduction": "Introduction",
+      "categories": "Categories",
+      "classGrade": "Class Grade",
       "description": "Description",
       "materials": "Materials Used",
       "category": "Category",
@@ -1124,7 +1132,10 @@
       "none": "None",
 
       "build": "Let's Make This Project",
-      "pdf": "Download Pdf",
+      "pdf": {
+        "downloading": "Downloading...",
+        "download": "Download PDF"
+      },
       "create": {
         "dialog": {
           "primary": "Create Activity",
@@ -1132,6 +1143,10 @@
           "proceed": "Proceed",
           "success": "activity Created successfully",
           "forbidden": "You must be staff monitor ao educator to be able to create a new activity "
+        },
+        "modal": {
+          "success": "Congratulations your Activity has been successfully created!",
+          "share": "Share your activity with the world. Post it on the following platforms:"
         }
       },
       "edit": {
@@ -1159,14 +1174,19 @@
          "label": "Publish"
       },
       "unpublish": {
-         "label": "UnPublish"
+         "label": "Unpublish"
       }
     },
       "saveButton": {
         "label": "save button",
         "save": "save",
         "unsave": "unsave"
-      }
+      },
+    "footer": {
+      "introductionText": "Did you like this activity?",
+      "buttonLabel": "Create it!",
+      "moreActivitiesTitle": "More Activities"
+    }
   },
   "breadCrumb":{
     "link":{

--- a/zubhub_frontend/zubhub/src/assets/js/colors.js
+++ b/zubhub_frontend/zubhub/src/assets/js/colors.js
@@ -1,22 +1,23 @@
 export const colors = {
-    primary: '#02B7C4',
-    "primary-01": "#E5F8F9",
-    secondary: '#DC3545',
-    tertiary: '#FECB00',
-    'tertiary-dark': '#C18D30',
-    black: '#292535',
-    gray: '#7E7E7E',
-    light: '#C4C4C4',
-    white: '#fff',
-    green: '#22C55E',
-    red: '#f44336',
-    'blue-light': '#00B8C433',
-    'blue-dark': '#7BA8AB',
-    'blue-pale': '#DBECFF'
-}
+  primary: '#02B7C4',
+  'primary-01': '#E5F8F9',
+  secondary: '#DC3545',
+  tertiary: '#FECB00',
+  'tertiary-dark': '#C18D30',
+  black: '#292535',
+  gray: '#7E7E7E',
+  light: '#C4C4C4',
+  white: '#fff',
+  green: '#22C55E',
+  red: '#f44336',
+  'blue-light': '#00B8C433',
+  'blue-dark': '#7BA8AB',
+  'blue-pale': '#DBECFF',
+  border: '#7E5B4B',
+};
 
 export const borders = {
-    borderRadius: 20,
-    borderRadiusMd: 8,
-    borderRadiusSm: 4,
-}
+  borderRadius: 20,
+  borderRadiusMd: 8,
+  borderRadiusSm: 4,
+};

--- a/zubhub_frontend/zubhub/src/assets/js/muiTheme.js
+++ b/zubhub_frontend/zubhub/src/assets/js/muiTheme.js
@@ -32,4 +32,17 @@ export const theme = createTheme({
       },
     },
   },
+  categoryColors: {
+    Animations: '#FCB07F',
+    Art: '#F8D991',
+    Science: '#FBC9B3',
+    Coding: '#65B4BD',
+    Electronics: '#F1D27C',
+    Toys: '#FAC5C2',
+    Games: '#6065A4',
+    Mechanical: '#F571AE',
+    Music: '#F1FC73',
+    Robotics: '#A66CA9',
+    Structures: '#FAE393',
+  },
 });

--- a/zubhub_frontend/zubhub/src/assets/js/styles/components/activity/activityStyle.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/components/activity/activityStyle.js
@@ -1,15 +1,14 @@
-export const style = theme => ({
+export const style = () => ({
   activityCardContainer: {
     position: 'relative',
-    // maxWidth: '350px',
-    // minWidth: '300px',
-    height: '95%',
+    width: '100%',
+    textAlign: 'left',
   },
   activityCard: {
     maxWidth: '100%',
-    borderRadius: '15px',
+    height: '33em',
+    borderRadius: '20px',
     position: 'relative!important',
-    height: '100%',
   },
   opacity: {
     backgroundColor: 'black',
@@ -29,55 +28,21 @@ export const style = theme => ({
   },
   mediaBoxStyle: {
     width: '100%',
-    height: '17em',
+    height: '13em',
     position: 'relative',
     padding: '2%',
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
   },
-  activityTagsBox: {
-    position: 'absolute',
-    top: '10px',
-    right: '10%',
-    display: 'flex',
-  },
-  activityTagPill: {
-    backgroundColor: 'white',
-    color: 'var(--text-color2)',
-    border: '1px solid var(--text-color2)',
-    '&:hover': {
-      backgroundColor: 'var(--text-color2)',
-      color: 'white',
-      border: '1px solid white',
-    },
-  },
-  activityTagsShowMore: {
-    '&:hover': {
-      backgroundColor: 'white',
-      color: 'var(--text-color2)',
-      border: '1px solid white',
-    },
-  },
-  tagsShowMoreIconContainer: {
-    //position: 'absolute',
-  },
-  tagsShowMoreList: {
-    position: 'absolute',
-    right: '0%',
-    backgroundColor: 'white',
-    maxHeight: '12em',
-    overflow: 'auto',
-    borderRadius: '10px',
-  },
-
   activityCardContent: {
     width: '100%',
-    position: 'relative',
-  },
-  activityCardInfoBox: {
-    height: '100%',
+    padding: '16px',
+    '&:last-child': {
+      paddingBottom: '12px',
+    },
     display: 'flex',
+    flexDirection: 'column',
     justifyContent: 'space-between',
   },
   projectsCount: {
@@ -92,10 +57,67 @@ export const style = theme => ({
     marginLeft: '5px',
   },
   activityTitle: {
-    fontSize: '1.1rem',
-    fontWeight: '900',
+    fontSize: '1.3rem',
+    fontWeight: 700,
     color: 'var(--text-color1)',
-    // width: '80%',
-    textAlign: '-webkit-auto',
+  },
+  activityDescription: {
+    height: '48px',
+    margin: '8px 0',
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
+    display: '-webkit-box',
+    '-webkit-line-clamp': 2,
+    '-webkit-box-orient': 'vertical',
+  },
+  activityCategoryContainer: {
+    margin: '12px 0',
+    display: 'flex',
+    flexWrap: 'nowrap',
+    gap: '8px',
+  },
+  activityCategory: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    fontSize: '0.9em',
+    padding: '2px 10px',
+    border: '1px solid #7E5B4B',
+    borderRadius: '10em',
+    background: '#F1D27C',
+  },
+  footer: {
+    marginTop: 10,
+    display: 'flex',
+    flexDirection: 'row',
+    flexWrap: 'nowrap',
+    overflow: 'hidden',
+  },
+  captionStyle: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  captionIconStyle: {
+    backgroundColor: '#eee',
+    padding: '2px 7px',
+    borderRadius: 25,
+    justifyContent: 'space-between',
+    fontWeight: '600',
+    display: 'flex',
+    alignItems: 'center',
+    marginRight: '1em',
+    '& svg': {
+      fill: 'rgba(0,0,0,0.54)',
+      marginRight: '0.5em',
+      fontSize: '1.1rem',
+    },
+  },
+  date: {
+    fontSize: '0.9rem',
+    fontWeight: '600',
+    marginLeft: 'auto',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
   },
 });

--- a/zubhub_frontend/zubhub/src/assets/js/utils/constants.js
+++ b/zubhub_frontend/zubhub/src/assets/js/utils/constants.js
@@ -7,6 +7,12 @@
  */
 export const BASE_TAGS = ['staff', 'moderator', 'group', 'creator'];
 
+export const USER_TAGS = {
+  staff: 'staff',
+  creator: 'creator',
+  educator: 'educator',
+};
+
 export const site_mode = {
   PUBLIC: 1,
   PRIVATE: 2,

--- a/zubhub_frontend/zubhub/src/components/activity/activity.jsx
+++ b/zubhub_frontend/zubhub/src/components/activity/activity.jsx
@@ -1,48 +1,27 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import clsx from 'clsx';
 import { makeStyles } from '@mui/styles';
-import BookmarkIcon from '@mui/icons-material/Bookmark';
-import BookmarkBorderIcon from '@mui/icons-material/BookmarkBorder';
-
-import {
-  Card,
-  CardActions,
-  CardContent,
-  CardMedia,
-  Typography,
-  Box,
-  List,
-  ListItem,
-  ListItemText,
-  Grid,
-  Fab,
-} from '@mui/material';
-
+import { Card, CardActions, CardContent, CardMedia, Typography, Box } from '@mui/material';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import EmojiObjectsIcon from '@mui/icons-material/EmojiObjects';
+import { style } from '../../assets/js/styles/components/activity/activityStyle';
 import { getActivities, activityToggleSave, setActivity } from '../../store/actions/activityActions';
 import commonStyles from '../../assets/js/styles';
-import Creator from '../creator/creator';
-import { toggleSave } from './activityScripts';
-import { style } from '../../assets/js/styles/components/activity/activityStyle';
+import { dFormatter } from '../../assets/js/utils/scripts';
+import Categories from '../categories/Categories';
+import Creators from '../creators/Creators';
 
 const useCommonStyles = makeStyles(commonStyles);
 const useStyles = makeStyles(style);
 function Activity(props) {
   const { activity, t } = { ...props };
-  const [tagsShowMore, setTagsShowMore] = useState(false);
   const classes = useStyles();
   const common_classes = useCommonStyles();
-  const topMarginCoefficient = activity.creator?.length < 6 ? 2 : 1;
-
   return (
     <div className={classes.activityCardContainer}>
-      {activity.creators?.length > 0
-        ? activity.creators.map((creator, index) => (
-            <Creator key={index} creator={creator} top={`${index * topMarginCoefficient - 1}em`} />
-          ))
-        : ''}
       <Link
         to={`/activities/${activity.id}`}
         className={common_classes.textDecorationNone}
@@ -55,92 +34,49 @@ function Activity(props) {
               alt={activity.title}
               className={classes.activityCardImage}
             />
-
-            <Box className={classes.activityTagsBox}>
-              {activity.tags?.length > 0
-                ? activity.tags.slice(0, 3).map(tag => (
-                    <Typography className={clsx(common_classes.baseTagStyle, classes.activityTagPill)} key={tag.id}>
-                      {tag.name}
-                    </Typography>
-                  ))
-                : ''}
-              {activity.tags?.length > 3 ? (
-                <div
-                  className={classes.tagsShowMoreIconContainer}
-                  onMouseOver={() => setTagsShowMore(true)}
-                  onMouseOut={() => setTagsShowMore(false)}
-                >
-                  <Typography
-                    className={clsx(common_classes.baseTagStyle, classes.activityTagsShowMore)}
-                    key="activityTagsShowMore"
-                  >
-                    {['+', activity.tags.length - 3].join('')}
-                  </Typography>
-                </div>
-              ) : (
-                ''
-              )}
-            </Box>
-
-            {tagsShowMore ? (
-              <Box
-                className={classes.tagsShowMoreList}
-                onMouseEnter={() => setTagsShowMore(true)}
-                onMouseLeave={() => setTagsShowMore(false)}
-              >
-                <List
-                  sx={{
-                    width: '100%',
-                    maxWidth: '150px',
-                    backgroundColor: 'background.paper',
-
-                    '& ul': { padding: 0 },
-                  }}
-                >
-                  {activity.tags?.map(tag => (
-                    <ListItem key={`tag-${tag.id}`}>
-                      <ListItemText primary={tag.name} />
-                    </ListItem>
-                  ))}
-                </List>
-              </Box>
-            ) : (
-              ''
-            )}
           </CardMedia>
           <CardActions>
             <CardContent className={classes.activityCardContent}>
-              <Fab
-                className={common_classes.fabButtonStyle}
-                size="small"
-                aria-label="save button"
-                onClick={e => toggleSave(e, activity.id, props.auth, props.navigate, props.activityToggleSave, t)}
+              <Typography variant="h5" component="h2" className={classes.activityTitle}>
+                {activity.title}
+              </Typography>
+              <Typography
+                variant="subtitle2"
+                color="textSecondary"
+                component="p"
+                className={classes.activityDescription}
               >
-                {props.auth && activity.saved_by.includes(props.auth.id) ? (
-                  <BookmarkIcon aria-label="unsave" />
-                ) : (
-                  <BookmarkBorderIcon aria-label="save" />
-                )}
-              </Fab>
-              <Grid container className={clsx(classes.activityCardInfoBox, common_classes.alignCenter)}>
-                <Grid item xs={6} sm={6}>
-                  <Typography variant="h6" component="h6" className={classes.activityTitle}>
-                    {activity.title}
-                  </Typography>
-                </Grid>
-                <Grid item>
-                  <Link
-                    to={`/activities/${activity.id}/linkedProjects`}
-                    className={common_classes.textDecorationNone}
-                    onClick={() => props.setActivity(activity)}
+                {activity.introduction.replace(/(<([^>]+)>)/gi, '')}
+              </Typography>
+              {activity.category.length > 0 && <Categories categories={activity.category} />}
+              <Creators creators={activity?.creators} />
+              <Box className={classes.footer}>
+                <Box className={classes.captionStyle}>
+                  <Typography
+                    className={classes.captionIconStyle}
+                    color="textSecondary"
+                    variant="caption"
+                    component="span"
                   >
-                    <Typography variant="caption" className={classes.projectsCount}>
-                      {`${t('activities.LinkedProjects')} `}{' '}
-                      <span className={classes.projectsCountNumber}>{` ${activity.inspired_projects.length}`}</span>
-                    </Typography>
-                  </Link>
-                </Grid>
-              </Grid>
+                    <VisibilityIcon /> {activity.views_count}
+                  </Typography>
+                  <Typography
+                    className={classes.captionIconStyle}
+                    color="textSecondary"
+                    variant="caption"
+                    component="span"
+                  >
+                    <EmojiObjectsIcon /> {activity.inspired_projects.length}
+                  </Typography>
+                </Box>
+                <Typography color="textSecondary" variant="caption" component="span" className={classes.date}>
+                  {`
+                    ${dFormatter(activity.created_on).value}
+                    ${t(`date.${dFormatter(activity.created_on).key}`)}
+                    ${t('date.ago')}
+                  `}
+                </Typography>
+              </Box>
             </CardContent>
           </CardActions>
         </Card>

--- a/zubhub_frontend/zubhub/src/components/categories/Categories.jsx
+++ b/zubhub_frontend/zubhub/src/components/categories/Categories.jsx
@@ -1,0 +1,24 @@
+import { makeStyles, useTheme } from '@mui/styles';
+import Chip from '@mui/material/Chip';
+import { styles } from './categories.styles';
+
+const Categories = ({ categories }) => {
+  const classes = makeStyles(styles)();
+  const theme = useTheme();
+  return (
+    <div className={classes.container}>
+      {categories?.map(category => (
+        <Chip
+          key={category}
+          label={category}
+          variant="outlined"
+          className={classes.chip}
+          size="small"
+          style={{ background: theme.categoryColors[category] }}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default Categories;

--- a/zubhub_frontend/zubhub/src/components/categories/categories.styles.js
+++ b/zubhub_frontend/zubhub/src/components/categories/categories.styles.js
@@ -1,0 +1,18 @@
+import { colors } from '../../assets/js/colors';
+
+export const styles = () => ({
+  container: {
+    border: '2px olid red',
+    margin: '12px 0',
+    display: 'flex',
+    flexWrap: 'nowrap',
+    gap: '8px',
+  },
+  chip: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    fontSize: '0.9em',
+    border: `1px solid ${colors.border}`,
+    borderRadius: '10em',
+  },
+});

--- a/zubhub_frontend/zubhub/src/components/creators/Creators.jsx
+++ b/zubhub_frontend/zubhub/src/components/creators/Creators.jsx
@@ -1,0 +1,88 @@
+import { makeStyles } from '@mui/styles';
+import { Link } from 'react-router-dom';
+import { Typography, Box, Avatar, Tooltip } from '@mui/material';
+import clsx from 'clsx';
+import { useTranslation } from 'react-i18next';
+import commonStyles from '../../assets/js/styles';
+import { creatorsStyles } from './creators.styles';
+
+const useCommonStyles = makeStyles(commonStyles);
+const useStyles = makeStyles(creatorsStyles);
+
+const Creators = ({ creators }) => {
+  const classes = useStyles();
+  const common_classes = useCommonStyles();
+  const { t } = useTranslation();
+
+  return (
+    <>
+      {creators.length === 1 ? (
+        creators.map((creator, index) => (
+          <Link
+            key={`${creator.username}-${index}`}
+            to={`/creators/${creator.username}`}
+            className={common_classes.textDecorationNone}
+          >
+            <Box className={classes.creatorBox}>
+              <Avatar className={classes.creatorAvatar} src={creator.avatar} alt={creator.username} />
+              <Tooltip title={creator.username} placement="bottom" arrow className={classes.creatorUsernameTooltip}>
+                <Box>
+                  <Typography color="textSecondary" variant="caption" component="p" className={classes.creatorUsername}>
+                    {creator.username}
+                  </Typography>
+                  {creator.tags.map((tag, index) => (
+                    <Typography
+                      key={`${tag}-${index}`}
+                      color="textPrimary"
+                      className={classes.creatorTag}
+                      component="p"
+                    >
+                      {tag}
+                    </Typography>
+                  ))}
+                </Box>
+              </Tooltip>
+            </Box>
+          </Link>
+        ))
+      ) : (
+        <Box className={classes.creatorBox}>
+          <Box className={clsx(creators?.length === 2 ? classes.twoCreatorBox : classes.multipleCreatorBox)}>
+            {creators.slice(0, 3).map((creator, index) => (
+              <Tooltip
+                key={`${creator.username}-${index}`}
+                title={
+                  index === 2 && creators.length > 3
+                    ? `${creators.length - 2} ${t('activities.tooltipMore')}`
+                    : creator.username
+                }
+                placement="bottom"
+                arrow
+                className={classes.creatorUsernameTooltip}
+                style={{ zIndex: index }}
+              >
+                {index === 2 && creators.length > 3 ? (
+                  <Avatar className={classes.creatorAvatar}>{`+${creators.length - 2}`}</Avatar>
+                ) : (
+                  <Avatar className={classes.creatorAvatar} src={creator.avatar} alt={creator.username} />
+                )}
+              </Tooltip>
+            ))}
+          </Box>
+          <Box>
+            <Typography color="textSecondary" variant="caption" component="p" className={classes.creatorUsername}>
+              {creators[creators.length - 1].username}
+            </Typography>
+            {creators[creators.length - 1].tags.map((tag, index) => (
+              <Typography key={`${tag}-${index}`} color="textPrimary" className={classes.creatorTag} component="p">
+                {tag}
+              </Typography>
+            ))}
+          </Box>
+        </Box>
+      )}
+    </>
+  );
+};
+
+export default Creators;

--- a/zubhub_frontend/zubhub/src/components/creators/creators.styles.js
+++ b/zubhub_frontend/zubhub/src/components/creators/creators.styles.js
@@ -1,0 +1,50 @@
+export const creatorsStyles = () => ({
+  creatorBox: {
+    margin: '15px 0 0.5em 0',
+    display: 'flex',
+    justifyContent: 'flex-start',
+    alignItems: 'center',
+    flexWrap: 'nowrap',
+    gap: '15px',
+    overflow: 'hidden',
+  },
+  twoCreatorBox: {
+    minWidth: '4em',
+    transition: '0.4s',
+    display: 'grid',
+    gridTemplateColumns: '1.5em 1.5em',
+    '&:hover': {
+      gridTemplateColumns: '3.2em 3.2em',
+    },
+  },
+  multipleCreatorBox: {
+    minWidth: '5.5em',
+    transition: '0.4s',
+    display: 'grid',
+    gridTemplateColumns: '1.5em 1.5em 1.5em',
+    '&:hover': {
+      gridTemplateColumns: '3.2em 3.2em 3.2em',
+    },
+  },
+  creatorAvatar: {
+    boxShadow: `0 3px 5px 2px rgba(0, 0, 0, .12)`,
+    background: 'white',
+    color: 'black',
+  },
+  creatorUsernameTooltip: {
+    marginRight: 'auto',
+    fontWeight: '400',
+  },
+  creatorUsername: {
+    flex: 1,
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+    fontWeight: '600',
+    fontSize: '1.1em',
+  },
+  creatorTag: {
+    fontWeight: '500',
+    fontSize: '0.9rem',
+  },
+});

--- a/zubhub_frontend/zubhub/src/components/social_share_buttons/socialShareButtons.jsx
+++ b/zubhub_frontend/zubhub/src/components/social_share_buttons/socialShareButtons.jsx
@@ -13,7 +13,7 @@ import { colors } from '../../assets/js/colors';
 import styles from '../../assets/js/styles/components/social_share_buttons/socialShareButtonsStyles';
 
 const useStyles = makeStyles(styles);
-const SocialButtons = ({ facebook, whatsapp, link, withColor, containerStyle = {} }) => {
+const SocialButtons = ({ facebook, whatsapp, link, withColor, containerStyle = {}, styleOverrides }) => {
   const { t } = useTranslation();
   const classes = useStyles();
   const url = window.location.href;
@@ -21,10 +21,10 @@ const SocialButtons = ({ facebook, whatsapp, link, withColor, containerStyle = {
 
   return (
     <>
-      <ButtonGroup className={classes.buttonGroup} style={containerStyle}>
+      <ButtonGroup className={clsx(classes.buttonGroup, styleOverrides?.containerStyle)} style={containerStyle}>
         {(showAll || facebook) && (
           <IconButton
-            className={clsx(classes.button, withColor && classes.outlined)}
+            className={clsx(classes.button, withColor && classes.outlined, styleOverrides?.outlined)}
             onClick={() =>
               window.open(
                 `https://www.facebook.com/sharer/sharer.php?u=${url}&quote=${t('projectDetails.socialShare.fbwa')}`,
@@ -38,7 +38,7 @@ const SocialButtons = ({ facebook, whatsapp, link, withColor, containerStyle = {
 
         {(showAll || whatsapp) && (
           <IconButton
-            className={clsx(classes.button, withColor && classes.outlined)}
+            className={clsx(classes.button, withColor && classes.outlined, styleOverrides?.outlined)}
             onClick={() =>
               window.open(`https://api.whatsapp.com/send?text=${t('projectDetails.socialShare.fbwa')} ${url}`)
             }
@@ -50,7 +50,7 @@ const SocialButtons = ({ facebook, whatsapp, link, withColor, containerStyle = {
 
         {(showAll || link) && (
           <IconButton
-            className={clsx(classes.button, withColor && classes.outlined)}
+            className={clsx(classes.button, withColor && classes.outlined, styleOverrides?.outlined)}
             onClick={() => {
               navigator.clipboard
                 .writeText(url)

--- a/zubhub_frontend/zubhub/src/views/activity_details/ActivityDetails.styles.js
+++ b/zubhub_frontend/zubhub/src/views/activity_details/ActivityDetails.styles.js
@@ -1,87 +1,135 @@
 import { colors } from '../../assets/js/colors';
 
-export const activityDefailsStyles = theme => ({
-  container: {
-    margin: '2em 24px',
-    [theme.breakpoints.down('378')]: {
-      marginTop: '3em 24px',
+export const activityDetailsStyles = theme => ({
+  mainContainer: {
+    [theme.breakpoints.down('sm')]: {
+      margin: '0 24px',
     },
-    // borderRadius: 8,
-    // backgroundColor: colors.white,
-    // padding: 24
-  },
-  descriptionBodyStyle: {
-    marginBottom: '0.7em',
-    color: 'rgba(0, 0, 0, 0.54)',
-    '& .ql-editor': {
-      fontSize: '1.01rem',
-      fontFamily: 'Raleway,Roboto,sans-serif',
-      padding: '4px 0',
-      lineHeight: 1.9,
+    [theme.breakpoints.down('xs')]: {
+      margin: '0 12px',
     },
   },
-  socialButtons: {
-    backgroundColor: colors.primary,
-    width: '100%',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    margin: '16px 0',
-    borderRadius: 8,
-  },
-  moreTextTitle: {
-    marginTop: 50,
-    marginBottom: 30,
-    fontSize: 22,
-    fontWeight: 'bold',
-    color: colors.black,
+  signedOutMainContainer: {
+    padding: '2em 12em',
+    [theme.breakpoints.down('sm')]: {
+      padding: '2em 0',
+    },
+    [theme.breakpoints.down('xs')]: {
+      padding: '3em 0',
+    },
   },
   card: {
     borderRadius: 8,
     backgroundColor: colors.white,
     padding: 24,
-  },
-  creatorProfileStyle: {
-    width: '100%',
-    display: 'flex',
-    alignItems: 'center',
-    marginBottom: '1em',
-    '& a': {
-      display: 'flex',
-      alignItems: 'center',
+    marginBottom: 40,
+    [theme.breakpoints.down('xs')]: {
+      padding: '24px 16px',
     },
-    [theme.breakpoints.down('500')]: {
-      width: '100%',
-      // justifyContent: 'space-between',
-    },
-  },
-  actionBoxButtonStyle: {
-    color: 'white',
-    '& MuiFab-root:hover': {
-      color: '#F2F2F2',
-    },
-    '& svg': {
-      fill: 'white',
-    },
-    '& svg:hover': {
-      fill: '#F2F2F2',
-    },
-  },
-  closed: {
-    height: 0,
-    transition: '0.4s',
-    overflow: 'hidden',
-  },
-  expandableMargin: {
-    // marginBottom: 10,
-    marginTop: 30,
-  },
-  expanded: {
-    transition: '0.4s',
-    height: 'fit-content',
     display: 'flex',
     flexDirection: 'column',
-    gap: 32,
-    marginTop: 20,
+    gap: 16,
+  },
+  headerFlex: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  headerTitle: {
+    fontWeight: 700,
+  },
+  headerButton: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: 4,
+    padding: '0 1.5em',
+    height: '2.5em',
+    '& .MuiButton-label': {
+      gap: '0.5em',
+    },
+  },
+  headerIconBox: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '1em',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    [theme.breakpoints.down('400')]: {
+      gap: '0.5em',
+      fontSize: '0.9em',
+    },
+  },
+  headerIconText: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.5em',
+    fontSize: '1em',
+    [theme.breakpoints.down('400')]: {
+      '& .MuiSvgIcon-root': {
+        fontSize: '1.2em',
+      },
+    },
+  },
+  creatorBox: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+  },
+  avatar: {
+    boxShadow: `0 3px 5px 2px rgba(0, 0, 0, .12)`,
+  },
+  creatorUsername: {
+    fontWeight: 500,
+    fontSize: 16,
+    textTransform: 'capitalize',
+    color: colors.black,
+  },
+  cardTitle: {
+    fontSize: '1.2em',
+    fontWeight: 600,
+  },
+  descriptionBodyStyle: {
+    '& .ql-editor': {
+      fontSize: '1.1em',
+      fontFamily: 'Raleway,Roboto,sans-serif',
+      lineHeight: 1.9,
+      margin: 0,
+      padding: 0,
+      '& ol': {
+        padding: 0,
+      },
+    },
+  },
+  classGrade: {
+    width: 'fit-content',
+    border: `1px solid ${colors.primary}`,
+  },
+  footer: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2em',
+    textAlign: 'center',
+  },
+  footerTitle: {
+    fontSize: 22,
+    fontWeight: 700,
+  },
+  menuItemIcon: {
+    minWidth: '2em',
+  },
+  dangerButton: {
+    color: colors.secondary,
+  },
+});
+
+export const socialButtonsStyleOverrides = () => ({
+  containerStyle: {
+    display: 'flex',
+  },
+  outlined: {
+    border: 'none',
   },
 });

--- a/zubhub_frontend/zubhub/src/views/profile/Profile.jsx
+++ b/zubhub_frontend/zubhub/src/views/profile/Profile.jsx
@@ -53,6 +53,7 @@ import styles from '../../assets/js/styles/views/profile/profileStyles';
 import commonStyles from '../../assets/js/styles';
 import ProjectsDraftsGrid from '../../components/projects_drafts/ProjectsDraftsGrid';
 import UserActivitylog from '../../components/user_activitylog/UserActivitylog';
+import { USER_TAGS } from '../../assets/js/utils/constants.js';
 
 const useStyles = makeStyles(styles);
 const useCommonStyles = makeStyles(commonStyles);
@@ -129,7 +130,7 @@ function Profile(props) {
         setNextPage(nextPageExist);
       });
     } catch (error) {
-      console.log(error);
+      console.log(error); // eslint-disable-line no-console
     }
   }, [page]);
 
@@ -184,17 +185,28 @@ function Profile(props) {
                     {profile.username}
                   </Typography>
                   <Box className={classes.tagsContainerStyle}>
-                    {sortTags(profile.tags).map(tag => (
+                    {props.location.state?.prevPath.split('/')[1] === 'activities' ? (
                       <Typography
-                        key={tag}
                         className={clsx(common_classes.baseTagStyle, {
-                          [common_classes.extendedTagStyle]: !isBaseTag(tag),
+                          [common_classes.extendedTagStyle]: !isBaseTag(USER_TAGS.educator),
                         })}
                         component="h2"
                       >
-                        {tag}
+                        {USER_TAGS.educator}
                       </Typography>
-                    ))}
+                    ) : (
+                      sortTags(profile.tags).map(tag => (
+                        <Typography
+                          key={tag}
+                          className={clsx(common_classes.baseTagStyle, {
+                            [common_classes.extendedTagStyle]: !isBaseTag(tag),
+                          })}
+                          component="h2"
+                        >
+                          {tag}
+                        </Typography>
+                      ))
+                    )}
                   </Box>
                   {props.auth.username === profile.username ? (
                     <>


### PR DESCRIPTION
## Summary

Redesigned activity details page according to the [new design](https://www.figma.com/file/nyUduEpFmVZ05xA8rt28Mt/ZubHub-Feature-Re-Designs?type=design&node-id=304-424&mode=design&t=LS8mVmTD3LVCmyfD-0). 

Depends on #1091 

Closes #1092 

## Changes

- Activity actions menu is shown if the user is the creator of the activity or a staff member.
- Activity actions menu shows 'publish'/ 'unpublish' button if the user is a staff member.

## Screenshots
<img height="600px" src="https://github.com/unstructuredstudio/zubhub/assets/92817363/014700d5-3b49-4690-9f96-c4d838ec9413" />
<img height="600px" src="https://github.com/unstructuredstudio/zubhub/assets/92817363/db2f4899-f9de-4137-bdbd-2012c1181936" />

## To Do

- [ ] Use `creators` component to show activity creators
- [x] Make 'publish' and 'unpublish' buttons functional

