### PR TITLE
Sidenav and path changes for activity feature

### DIFF
--- a/.github/workflows/build_deploy_frontend.yml
+++ b/.github/workflows/build_deploy_frontend.yml
@@ -37,8 +37,8 @@ jobs:
 
       - uses: unstructuredstudio/zubhub/.github/actions/scp_action@master
         with:
-          host: ${{ vars.DO_BACKEND_HOST }}
-          username: ${{ vars.DO_BACKEND_USERNAME }}
+          host: ${{ vars.DO_FRONTEND_HOST }}
+          username: ${{ vars.DO_FRONTEND_USERNAME }}
           key: ${{ secrets.DO_SSHKEY }}
           source: "."
           target: "/home/zubhub-frontend/zubhub"
@@ -65,7 +65,7 @@ jobs:
           script: |
 
             docker system prune -a -f
-            
+
             volumes=$(docker volume ls -q)
             # Loop through the volumes
             while IFS= read -r volume; do

--- a/zubhub_frontend/zubhub/package-lock.json
+++ b/zubhub_frontend/zubhub/package-lock.json
@@ -23,6 +23,7 @@
         "axios": "^1.5.1",
         "caniuse-lite": "^1.0.30001543",
         "classnames": "^2.2.6",
+        "clsx": "^2.1.0",
         "compressorjs": "^1.0.7",
         "dayjs": "^1.11.10",
         "formik": "^2.2.5",

--- a/zubhub_frontend/zubhub/package.json
+++ b/zubhub_frontend/zubhub/package.json
@@ -18,6 +18,7 @@
     "axios": "^1.5.1",
     "caniuse-lite": "^1.0.30001543",
     "classnames": "^2.2.6",
+    "clsx": "^2.1.0",
     "compressorjs": "^1.0.7",
     "dayjs": "^1.11.10",
     "formik": "^2.2.5",

--- a/zubhub_frontend/zubhub/public/locales/en/translation.json
+++ b/zubhub_frontend/zubhub/public/locales/en/translation.json
@@ -649,7 +649,7 @@
     },
     "activityLog": {
       "activity": "Activity Log",
-      "addActivityLog": "Seems like there isn't any activity on your account yet! Get involved to see activity logs!" 
+      "addActivityLog": "Seems like there isn't any activity on your account yet! Get involved to see activity logs!"
     },
     "team": "Team",
     "createteam": "Create Team",
@@ -949,6 +949,7 @@
       "primary": "Create Activity",
       "edit": "Update Activity"
     },
+    "unauthorized": "You have to be an educator to create activities",
     "inputs": {
       "title": {
         "label": "Name your Activity",

--- a/zubhub_frontend/zubhub/src/components/Sidenav/data.js
+++ b/zubhub_frontend/zubhub/src/components/Sidenav/data.js
@@ -1,45 +1,43 @@
 import { GiNotebook } from 'react-icons/gi';
-import { TEAM_ENABLED } from '../../utils.js';
 import { RiLogoutBoxRFill, RiTeamFill } from 'react-icons/ri';
 import {
-    Bookmark,
-    Dashboard,
-    EmojiObjects,
-    ExpandMore,
-    FeaturedPlayList,
-    Person,
-    PostAddOutlined,
-    Publish,
-    Settings,
+  Bookmark,
+  Dashboard,
+  EmojiObjects,
+  FeaturedPlayList,
+  Person,
+  PostAddOutlined,
+  Publish,
 } from '@mui/icons-material';
+import { TEAM_ENABLED } from '../../utils.js';
 
-export const links = ({ draftCount, myProjectCount, auth, t }) => [
-    { label: t('pageWrapper.sidebar.projects'), link: '/', icon: Dashboard },
-    { label: t('pageWrapper.sidebar.profile'), link: '/profile', icon: Person, reactIcon: true, requireAuth: true },
-    { label: t('pageWrapper.sidebar.createProject'), link: '/projects/create', icon: EmojiObjects },
-    ...(auth?.tags.includes('staff')
-        ? [{ label: t('pageWrapper.sidebar.createActivity'), link: '/activities/create', icon: PostAddOutlined }]
-        : []),
-    {
-        label: `${t('pageWrapper.sidebar.myDrafts')}`,
-        link: `/creators/${auth?.username}/drafts`,
-        icon: GiNotebook,
-        requireAuth: true,
-        customButton: true,
-    },
-    {
-        label: `${t('pageWrapper.sidebar.myProjects')}`,
-        link: `/creators/${auth?.username}/projects`,
-        icon: Publish,
-        requireAuth: true,
-        customButton: true,
-    },
-    { label: t('pageWrapper.sidebar.bookmarks'), link: '/projects/saved', icon: Bookmark, requireAuth: true },
-    ...(TEAM_ENABLED ? [{ label: t('pageWrapper.sidebar.teams'), link: '/teams/all', icon: RiTeamFill }] : []),
-    { label: t('pageWrapper.sidebar.expoloreActivities'), link: 'https://kriti.unstructured.studio/', target: '_blank', icon: FeaturedPlayList },
+export const links = ({ auth, t }) => [
+  { label: t('pageWrapper.sidebar.projects'), link: '/', icon: Dashboard },
+  { label: t('pageWrapper.sidebar.profile'), link: '/profile', icon: Person, reactIcon: true, requireAuth: true },
+  { label: t('pageWrapper.sidebar.createProject'), link: '/projects/create', icon: EmojiObjects },
+  ...(auth?.tags.includes('staff') || auth?.tags.includes('educator')
+    ? [{ label: t('pageWrapper.sidebar.createActivity'), link: '/activities/create', icon: PostAddOutlined }]
+    : []),
+  {
+    label: `${t('pageWrapper.sidebar.myDrafts')}`,
+    link: `/creators/${auth?.username}/drafts`,
+    icon: GiNotebook,
+    requireAuth: true,
+    customButton: true,
+  },
+  {
+    label: `${t('pageWrapper.sidebar.myProjects')}`,
+    link: `/creators/${auth?.username}/projects`,
+    icon: Publish,
+    requireAuth: true,
+    customButton: true,
+  },
+  { label: t('pageWrapper.sidebar.bookmarks'), link: '/projects/saved', icon: Bookmark, requireAuth: true },
+  ...(TEAM_ENABLED ? [{ label: t('pageWrapper.sidebar.teams'), link: '/teams/all', icon: RiTeamFill }] : []),
+  { label: t('pageWrapper.sidebar.expoloreActivities'), link: '/activities', icon: FeaturedPlayList },
 ];
 
 export const bottomLinks = ({ t }) => [
-    // { label: t('pageWrapper.sidebar.settings'), link: '/settings', icon: Settings, requireAuth: true },
-    { label: t('pageWrapper.sidebar.logout'), action: 'logout', icon: RiLogoutBoxRFill, red: true, requireAuth: true },
+  // { label: t('pageWrapper.sidebar.settings'), link: '/settings', icon: Settings, requireAuth: true },
+  { label: t('pageWrapper.sidebar.logout'), action: 'logout', icon: RiLogoutBoxRFill, red: true, requireAuth: true },
 ];

--- a/zubhub_frontend/zubhub/src/views/create_activity/CreateActivity.jsx
+++ b/zubhub_frontend/zubhub/src/views/create_activity/CreateActivity.jsx
@@ -1,46 +1,30 @@
 import { makeStyles } from '@mui/styles';
-import {
-  Box,
-  CircularProgress,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
-  Grid,
-  Link,
-  Typography,
-  useMediaQuery,
-} from '@mui/material';
+import { Box, CircularProgress, Dialog, Grid, Link, Typography, useMediaQuery } from '@mui/material';
 import React, { useEffect, useRef, useState } from 'react';
-import { CustomButton, Modal, PreviewActivity, TagsInput } from '../../components';
 import StepWizard from 'react-step-wizard';
+import { useFormik } from 'formik';
+import { useSelector } from 'react-redux';
 import {
   ArrowBackIosRounded,
   ArrowForwardIosRounded,
-  CloseOutlined,
   CloudDoneOutlined,
   DoneRounded,
   KeyboardBackspaceRounded,
 } from '@mui/icons-material';
-import { AiOutlineExclamationCircle } from 'react-icons/ai';
-import { createActivityStyles } from './CreateActivity.styles';
 import clsx from 'clsx';
-import { colors } from '../../assets/js/colors';
+import { CustomButton, PreviewActivity } from '../../components';
+import { createActivityStyles } from './CreateActivity.styles';
 import styles from '../../assets/js/styles';
 import { useDomElementHeight } from '../../hooks/useDomElementHeight.hook';
-import { toast } from 'react-toastify';
-import { useFormik } from 'formik';
 import * as script from './script';
-import CreateActivityStep1 from './create_activity_step1';
 import Step1 from './step1/Step1';
 import Step2 from './step2/Step2';
-import { useSelector } from 'react-redux';
+import ErrorPage from '../error/ErrorPage';
 
 const DRAFT_STATUSES = { saved: 'SAVED', saving: 'SAVING', idle: 'IDLE' };
 const steps = ['Activity Basics', 'Activity Details'];
 
-let firstRender = true;
+const firstRender = true;
 
 export default function CreateActivity(props) {
   const { height } = useDomElementHeight('navbar-root');
@@ -61,6 +45,9 @@ export default function CreateActivity(props) {
 
   const isActive = index => index + 1 === activeStep;
   const isCompleted = index => completedSteps.includes(index + 1);
+  const { t } = props;
+  const formikStep1 = useFormik(script.step1Schema);
+  const formikStep2 = useFormik(script.step2Schema);
 
   const handleSetState = obj => {
     if (obj) {
@@ -76,7 +63,7 @@ export default function CreateActivity(props) {
         setIsLoading(true);
         script
           .getActivity({ ...props, auth, formikStep1, formikStep2 }, state)
-          .then(result => {})
+          .then(() => {})
           .finally(() => setIsLoading(false));
       }
     }
@@ -98,37 +85,6 @@ export default function CreateActivity(props) {
     if (draftStatus === DRAFT_STATUSES.saved) return !isSmallScreen ? 'Saved to draft' : '';
   };
 
-  const formikStep1 = useFormik(script.step1Schema);
-  const formikStep2 = useFormik(script.step2Schema);
-
-  const previous = () => go('prev');
-  const next = async () => {
-    let error = await checkErrors();
-
-    console.log(error);
-    if (Object.keys(error || {}).length > 0) return;
-
-    setIsLoading(true);
-
-    script.submitForm(
-      {
-        step1Values: formikStep1.values,
-        step2Values: formikStep2.values,
-        props: { ...props, auth },
-        state,
-        handleSetState: handleSetState,
-        step: activeStep,
-      },
-      success => {
-        if (success) {
-          if (activeStep == 1) go('next');
-          if (activeStep == 2) props.navigate(`/activities/${props.params.id}?success=true`);
-          setIsLoading(false);
-        }
-      },
-    );
-  };
-
   const checkErrors = () => {
     if (activeStep === 1) {
       return formikStep1.setTouched({ title: true }, true);
@@ -143,7 +99,7 @@ export default function CreateActivity(props) {
     if (direction === 'next') {
       if (activeStep !== 3) {
         wizardRef.current.nextStep();
-        let completedStepsTemp = [...new Set([...completedSteps, activeStep])];
+        const completedStepsTemp = [...new Set([...completedSteps, activeStep])];
         setcompletedSteps(completedStepsTemp);
         if (activeStep !== 2) {
           setActiveStep(step => step + 1);
@@ -156,6 +112,33 @@ export default function CreateActivity(props) {
         setActiveStep(step => step - 1);
       }
     }
+  };
+  const previous = () => go('prev');
+  const next = async () => {
+    const error = await checkErrors();
+
+    console.log(error);
+    if (Object.keys(error || {}).length > 0) return;
+
+    setIsLoading(true);
+
+    script.submitForm(
+      {
+        step1Values: formikStep1.values,
+        step2Values: formikStep2.values,
+        props: { ...props, auth },
+        state,
+        handleSetState,
+        step: activeStep,
+      },
+      success => {
+        if (success) {
+          if (activeStep === 1) go('next');
+          if (activeStep === 2) props.navigate(`/activities/${props.params.id}?success=true`);
+          setIsLoading(false);
+        }
+      },
+    );
   };
 
   const renderSteps = steps.map((label, index) => (
@@ -176,71 +159,75 @@ export default function CreateActivity(props) {
     </Box>
   ));
 
-  return (
-    <div className={classes.container}>
-      <Dialog open={preview} fullScreen>
-        <PreviewActivity {...props} onClose={togglePreview} />
-      </Dialog>
-      {/* Banner */}
-      <Box className={classes.banner}>
-        <KeyboardBackspaceRounded />
-        <>
-          <CustomButton onClick={togglePreview} className={classes.previewButton} variant="outlined">
-            Preview
-          </CustomButton>
-          <Box className={clsx(classes.draft, draftStatus === DRAFT_STATUSES.saved && classes.savedToDraft)}>
-            {draftStatus === DRAFT_STATUSES.saving ? <CircularProgress size={20} color="inherit" /> : null}
-            {draftStatus === DRAFT_STATUSES.saved ? <CloudDoneOutlined size={20} color="inherit" /> : null}
-
-            <Link className={classes.linkToDraft} href={`/creators/${props.auth?.username}/drafts`}>
-              <Typography>{draftContainerText()}</Typography>
-            </Link>
-          </Box>
-        </>
-      </Box>
-
-      {/* Form */}
-      <Box className={classes.formContainer}>
-        <Grid item md={12} lg={12}>
-          <Box sx={{ textAlign: isSmallScreen ? 'left' : 'center' }}>
-            <Typography className={clsx(commonClasses.title1)}>Create Activity</Typography>
-            <Typography>Tell us about your informative activity !</Typography>
-          </Box>
-
-          {/* Step Navigation UI */}
-          <Box className={classes.stepperContainer}>{renderSteps}</Box>
-
-          <Box style={{ marginTop: 100 }}>
-            <StepWizard initialStep={activeStep} ref={wizardRef}>
-              <Step1 formik={formikStep1} />
-              <Step2 formik={formikStep2} id={props.match?.params.id} />
-            </StepWizard>
-          </Box>
-        </Grid>
-
-        {/* Previous and Next buttons */}
-        <Box className={classes.buttonGroup}>
-          {activeStep > 1 && (
-            <CustomButton
-              onClick={previous}
-              primaryButtonOutlinedStyle
-              startIcon={<ArrowBackIosRounded className={classes.nextButton} />}
-            >
-              Previous
+  if (!auth?.tags.includes('educator') || !auth?.tags.includes('staff')) {
+    return <ErrorPage error={t('createActivity.unauthorized')} />;
+  } else {
+    return (
+      <div className={classes.container}>
+        <Dialog open={preview} fullScreen>
+          <PreviewActivity {...props} onClose={togglePreview} />
+        </Dialog>
+        {/* Banner */}
+        <Box className={classes.banner}>
+          <KeyboardBackspaceRounded />
+          <>
+            <CustomButton onClick={togglePreview} className={classes.previewButton} variant="outlined">
+              Preview
             </CustomButton>
-          )}
+            <Box className={clsx(classes.draft, draftStatus === DRAFT_STATUSES.saved && classes.savedToDraft)}>
+              {draftStatus === DRAFT_STATUSES.saving ? <CircularProgress size={20} color="inherit" /> : null}
+              {draftStatus === DRAFT_STATUSES.saved ? <CloudDoneOutlined size={20} color="inherit" /> : null}
 
-          <CustomButton
-            onClick={next}
-            loading={isLoading}
-            style={{ marginLeft: 'auto' }}
-            primaryButtonStyle
-            endIcon={<ArrowForwardIosRounded className={classes.nextButton} />}
-          >
-            {activeStep == 2 ? 'Publish' : 'Next'}
-          </CustomButton>
+              <Link className={classes.linkToDraft} href={`/creators/${props.auth?.username}/drafts`}>
+                <Typography>{draftContainerText()}</Typography>
+              </Link>
+            </Box>
+          </>
         </Box>
-      </Box>
-    </div>
-  );
+
+        {/* Form */}
+        <Box className={classes.formContainer}>
+          <Grid item md={12} lg={12}>
+            <Box sx={{ textAlign: isSmallScreen ? 'left' : 'center' }}>
+              <Typography className={clsx(commonClasses.title1)}>Create Activity</Typography>
+              <Typography>Tell us about your informative activity !</Typography>
+            </Box>
+
+            {/* Step Navigation UI */}
+            <Box className={classes.stepperContainer}>{renderSteps}</Box>
+
+            <Box style={{ marginTop: 100 }}>
+              <StepWizard initialStep={activeStep} ref={wizardRef}>
+                <Step1 formik={formikStep1} />
+                <Step2 formik={formikStep2} id={props.match?.params.id} />
+              </StepWizard>
+            </Box>
+          </Grid>
+
+          {/* Previous and Next buttons */}
+          <Box className={classes.buttonGroup}>
+            {activeStep > 1 && (
+              <CustomButton
+                onClick={previous}
+                primaryButtonOutlinedStyle
+                startIcon={<ArrowBackIosRounded className={classes.nextButton} />}
+              >
+                Previous
+              </CustomButton>
+            )}
+
+            <CustomButton
+              onClick={next}
+              loading={isLoading}
+              style={{ marginLeft: 'auto' }}
+              primaryButtonStyle
+              endIcon={<ArrowForwardIosRounded className={classes.nextButton} />}
+            >
+              {activeStep === 2 ? 'Publish' : 'Next'}
+            </CustomButton>
+          </Box>
+        </Box>
+      </div>
+    );
+  }
 }


### PR DESCRIPTION
## Summary

This PR addresses the changes mentioned in #1099. 

Closes #1099

## Changes

- Create activity button is visible to 'educator' and 'staff' role users
- Creators get a warning when they try to visit `/activities/create`
- Explore Activities button in the sidenav redirect the users to `/activities`

## Screenshots
**For Educators:**
<img width="399" alt="Screenshot 2024-02-15 at 10 21 43 PM" src="https://github.com/unstructuredstudio/zubhub/assets/92817363/e3749643-491f-4db8-ac69-074bd042f30e">

**For Creators:**
<img width="1343" alt="Screenshot 2024-02-15 at 10 22 08 PM" src="https://github.com/unstructuredstudio/zubhub/assets/92817363/42ce91be-6009-406b-9caa-113a252ab2dd">
