### PR TITLE
Revert "feat: add tags to creator registration"

### DIFF
--- a/zubhub_backend/zubhub/creators/adapter.py
+++ b/zubhub_backend/zubhub/creators/adapter.py
@@ -38,7 +38,6 @@ class CustomAccountAdapter(DefaultAccountAdapter):
         creator.bio = data.get('bio')
         creator.location = location
         creator.is_active = is_active
-        creator.tags.set(data.get('creator_tags'))
         creator.save()
 
         Setting(creator=creator, subscribe=data.get("subscribe")).save()

--- a/zubhub_backend/zubhub/creators/serializers.py
+++ b/zubhub_backend/zubhub/creators/serializers.py
@@ -8,7 +8,8 @@ from django.contrib.auth import get_user_model
 from django.utils.translation import gettext_lazy as _
 import csv
 from .admin import badges
-from .models import CreatorGroup, Creator, CreatorGroupMembership, Location, PhoneNumber, CreatorTag
+from .models import CreatorGroup, Creator, CreatorGroupMembership
+from .models import Location, PhoneNumber
 from allauth.account.models import EmailAddress
 from rest_auth.registration.serializers import RegisterSerializer
 from rest_auth.serializers import PasswordResetSerializer
@@ -198,8 +199,6 @@ class CustomRegisterSerializer(RegisterSerializer):
                                             queryset=Location.objects.all())
     bio = serializers.CharField(allow_blank=True, default="", max_length=255)
     subscribe = serializers.BooleanField(default=False)
-    creator_tags = serializers.SlugRelatedField(slug_field='name',
-                                                queryset=CreatorTag.objects.all())
 
     def validate_username(self, username):
         # Check if the value is a valid email
@@ -248,14 +247,6 @@ class CustomRegisterSerializer(RegisterSerializer):
             raise serializers.ValidationError(_("Location is required"))
         return location
 
-    def validate_creator_tags(self, creator_tags):
-        if (len(creator_tags) < 1):
-            raise serializers.ValidationError(_("Creator tags are required"))
-        for tag in creator_tags:
-            if not CreatorTag.objects.filter(name=tag).exists():
-                raise serializers.ValidationError(_("Invalid creator tag: {}".format(tag)))
-        return creator_tags
-
     def get_cleaned_data(self):
         data_dict = super().get_cleaned_data()
         data_dict['phone'] = self.validated_data.get('phone', '')
@@ -263,7 +254,6 @@ class CustomRegisterSerializer(RegisterSerializer):
         data_dict['location'] = self.validated_data.get('location', '')
         data_dict['bio'] = self.validated_data.get('bio', '')
         data_dict['subscribe'] = self.validated_data.get('subscribe', '')
-        data_dict['creator_tags'] = self.validated_data.get('creator_tags', [])
 
         return data_dict
 

--- a/zubhub_backend/zubhub/creators/views.py
+++ b/zubhub_backend/zubhub/creators/views.py
@@ -1,3 +1,5 @@
+import csv
+from io import StringIO
 from django.forms import ValidationError
 from django.utils.translation import ugettext_lazy as _
 from notifications.models import Notification
@@ -186,7 +188,6 @@ class RegisterCreatorAPIView(RegisterView):
             "location": "string",\n
             "bio": "",\n
             "subscribe": false\n
-            "creator_tags": "string",\n
         }\n
     """
 


### PR DESCRIPTION
Reverts unstructuredstudio/zubhub#1082

there is an error in this PR that makes it impossible to register a new user. @yokwejuste you should look at this again and try to verify that it works before creating a PR again. I assumed you already did that so didn't test properly before merging. Possibly try to get the tests in `zubhub_backend/zubhub/creators/tests/test_views.py` to pass.