### PR TITLE
[backend] pin pip to 24.0

### DIFF
--- a/zubhub_backend/compose/celery/prod/Dockerfile
+++ b/zubhub_backend/compose/celery/prod/Dockerfile
@@ -19,7 +19,9 @@ WORKDIR /celery
 # copying neccessary files to work directory
 COPY ./compose/celery/requirements.txt /celery/
 
-RUN pip install --upgrade pip wheel \
+RUN pip install --upgrade wheel \
+  # pip versions greater than 24.0 fails to install celery 4.4.0. pin pip until we are ready to upgrade celery
+  && pip install pip==24.0 \
   # Requirements are installed here to ensure they will be cached.
   && pip install -r /celery/requirements.txt
 

--- a/zubhub_backend/compose/flower/prod/Dockerfile
+++ b/zubhub_backend/compose/flower/prod/Dockerfile
@@ -21,7 +21,9 @@ WORKDIR /flower
 # copying neccessary files to work directory
 COPY ./compose/flower/requirements.txt /flower/
 
-RUN pip install --upgrade pip wheel \
+RUN pip install --upgrade wheel \
+  # pip versions greater than 24.0 fails to install celery 4.4.0. pin pip until we are ready to upgrade celery
+  && pip install pip==24.0 \
   # Requirements are installed here to ensure they will be cached.
   && pip install -r /flower/requirements.txt
 

--- a/zubhub_backend/compose/media/dev/Dockerfile
+++ b/zubhub_backend/compose/media/dev/Dockerfile
@@ -23,7 +23,9 @@ WORKDIR /home
 # copying neccessary files to work directory
 COPY ./compose/media/requirements.txt /home/
 
-RUN pip install --upgrade pip wheel \
+RUN pip install --upgrade wheel \
+  # pip versions greater than 24.0 fails to install celery 4.4.0. pin pip until we are ready to upgrade celery
+  && pip install pip==24.0 \
   # Requirements are installed here to ensure they will be cached.
   && pip install -r /home/requirements.txt
 

--- a/zubhub_backend/compose/media/prod/Dockerfile
+++ b/zubhub_backend/compose/media/prod/Dockerfile
@@ -22,7 +22,9 @@ WORKDIR /home
 # copying neccessary files to work directory
 COPY ./compose/media/requirements.txt /home/
 
-RUN pip install --upgrade pip wheel \
+RUN pip install --upgrade wheel \
+  # pip versions greater than 24.0 fails to install celery 4.4.0. pin pip until we are ready to upgrade celery
+  && pip install pip==24.0 \
   # Requirements are installed here to ensure they will be cached.
   && pip install -r /home/requirements.txt
 

--- a/zubhub_backend/compose/web/dev/Dockerfile
+++ b/zubhub_backend/compose/web/dev/Dockerfile
@@ -24,7 +24,9 @@ WORKDIR /zubhub_backend
 # copying neccessary files to work directory
 COPY ./compose/web/requirements.txt /zubhub_backend/
 
-RUN pip install --upgrade pip wheel \
+RUN pip install --upgrade wheel \
+  # pip versions greater than 24.0 fails to install celery 4.4.0. pin pip until we are ready to upgrade celery
+  && pip install pip==24.0 \
   # Requirements are installed here to ensure they will be cached.
   && pip install -r /zubhub_backend/requirements.txt
 

--- a/zubhub_backend/compose/web/prod/Dockerfile
+++ b/zubhub_backend/compose/web/prod/Dockerfile
@@ -23,7 +23,9 @@ WORKDIR /zubhub_backend
 # copying neccessary files to work directory
 COPY ./compose/web/requirements.txt /zubhub_backend/
 
-RUN pip install --upgrade pip wheel \
+RUN pip install --upgrade wheel \
+  # pip versions greater than 24.0 fails to install celery 4.4.0. pin pip until we are ready to upgrade celery
+  && pip install pip==24.0 \
   # Requirements are installed here to ensure they will be cached.
   && pip install -r /zubhub_backend/requirements.txt
 


### PR DESCRIPTION
pin pip to version 24.0. versions > 24.0 fails to install celery.
Pin to 24.0 until we have time to upgrade celery and other things